### PR TITLE
BUGFIX 

### DIFF
--- a/code/dataobjects/WorkflowDefinition.php
+++ b/code/dataobjects/WorkflowDefinition.php
@@ -83,8 +83,10 @@ class WorkflowDefinition extends DataObject {
 
 		$fields->addFieldToTab('Root.Main', new TextField('Title', _t('WorkflowDefinition.TITLE', 'Title')));
 		$fields->addFieldToTab('Root.Main', new TextareaField('Description', _t('WorkflowDefinition.DESCRIPTION', 'Description')));
-		$fields->addFieldToTab('Root.Main', new CheckboxSetField('Users', _t('WorkflowDefinition.USERS', 'Users'), $cmsUsers));
-		$fields->addFieldToTab('Root.Main', new TreeMultiselectField('Groups', _t('WorkflowDefinition.GROUPS', 'Groups'), 'Group'));
+		if($this->ID) {
+			$fields->addFieldToTab('Root.Main', new CheckboxSetField('Users', _t('WorkflowDefinition.USERS', 'Users'), $cmsUsers));
+			$fields->addFieldToTab('Root.Main', new TreeMultiselectField('Groups', _t('WorkflowDefinition.GROUPS', 'Groups'), 'Group'));
+		}
 
 		if (class_exists('AbstractQueuedJob')) {
 			$before = _t('WorkflowDefinition.SENDREMINDERDAYSBEFORE', 'Send reminder email after ');


### PR DESCRIPTION
Only display the groups and users fields once the record has been saved for the first time, in order to avoid the addManyMany/missing foreign ID error message when CMS user creates a new workflow definition and select some groups or users before saving for the first time.
