### PR TITLE
BUGFIX

### DIFF
--- a/javascript/WorkflowField.js
+++ b/javascript/WorkflowField.js
@@ -135,7 +135,9 @@ jQuery.entwine("workflow", function($) {
 	$(".workflow-field .workflow-field-delete").entwine({
 		onclick: function() {
 			if(confirm("Are you sure you want to permanently delete this?")) {
-				
+				$.post(this.prop('href')).done(function(body) {
+					$(".workflow-field").replaceWith(body);
+				});
 			}
 
 			return false;


### PR DESCRIPTION
 Implementation of the javascript ajax request for workflow action deletion. At the moment, pressing "Delete" for an action in a workflow definition shows a confirmation pop up, but the step is not deleted after saying Yes
