### PR TITLE
BUGFIX 

### DIFF
--- a/code/extensions/WorkflowApplicable.php
+++ b/code/extensions/WorkflowApplicable.php
@@ -78,7 +78,7 @@ class WorkflowApplicable extends DataExtension {
 	public function updateCMSActions(FieldList $actions) {
 		$active = $this->workflowService->getWorkflowFor($this->owner);
 
-		if (Controller::curr() instanceof CMSPageEditController){
+		if (Controller::curr() && Controller::curr()->hasExtension('AdvancedWorkflowExtension')){
 			if ($active) {
 				if ($this->canEditWorkflow()) {
 					$action = new FormAction('updateworkflow', $active->CurrentAction() ? $active->CurrentAction()->Title : _t('WorkflowApplicable.UPDATE_WORKFLOW', 'Update Workflow'));


### PR DESCRIPTION
Only show the actions if on the "Content" tab, as AdvancedWorkflowExtension doesn't decorate CMSPageSettingsController. This is to prevent a "Not found" error message when pressing a workflow action button, when on the "Settings" panel of a page.
