### PR TITLE
BUGFIX 

### DIFF
--- a/code/dataobjects/WorkflowActionInstance.php
+++ b/code/dataobjects/WorkflowActionInstance.php
@@ -30,6 +30,13 @@ class WorkflowActionInstance extends DataObject {
 		'Member.Name'			=> 'Author'
 	);
 	
+	public static $field_labels = array(
+		'BaseAction.Title'		=> 'Title',
+		'Comment'				=> 'Comment',
+		'Created'				=> 'Date',
+		'Member.Name'			=> 'Author'
+	);
+	
 	/**
 	 * Gets fields for when this is part of an active workflow
 	 */


### PR DESCRIPTION
Set a fields_label on workflow instance so the log table displays some data. When trying to display data through relationships (ie Member.Name) in a gridfield, a $field_labels static variable must be defined or the columns are not displayed for the whole table.
