### PR TITLE
NEW 

### DIFF
--- a/code/dataobjects/WorkflowAction.php
+++ b/code/dataobjects/WorkflowAction.php
@@ -122,7 +122,9 @@ class WorkflowAction extends DataObject {
 	 */
 	public function onAfterDelete() {
 		parent::onAfterDelete();
-		$wfActionInstances = WorkflowActionInstance::get()->filter('BaseActionID', $this->ID);
+		$wfActionInstances = WorkflowActionInstance::get()
+				->leftJoin("WorkflowInstance",'"WorkflowInstance"."ID" = "WorkflowActionInstance"."WorkflowID"')
+				->where(sprintf('"BaseActionID" = %d AND ("WorkflowStatus" IN (\'Active\',\'Paused\'))', $this->ID));
 		foreach ($wfActionInstances as $wfActionInstance){
 			$wfInstances = WorkflowInstance::get()->filter('CurrentActionID', $wfActionInstance->ID);
 			foreach ($wfInstances as $wfInstance){


### PR DESCRIPTION
Perform a clean up of workflow action and transition instances when an action is deleted from a workflow definition. When a page has a workflow assigned which is paused on an action, deleting this action leaves the workflow in an unstable state, and the workflow is stuck. I have chosen the approach to delete the workflow instance (as well as outbound transitions, which are not editable in the backend anymore anyway). I also thought that we could try to rollback the workflow to the latest known action, but it gets tricky if the action was the merging point of two branches in a workflow. I'm open for discussion though, as I understand this commit can be controversial.
