### PR TITLE
This pull request is actually for issue #31 and #32, I just have given a wrong branch name.

### DIFF
--- a/code/actions/NotifyUsersWorkflowAction.php
+++ b/code/actions/NotifyUsersWorkflowAction.php
@@ -107,7 +107,8 @@ class NotifyUsersWorkflowAction extends WorkflowAction {
 
 		$email->setSubject($subject);
 		$email->setFrom($this->EmailFrom);
-		$email->setBcc(substr($emails, 0, -2));
+		$email->setTo(substr($emails, 0, -2));
+		if($member->Email) $email->setCc($member->Email);
 		$email->setBody($body);
 		$email->send();
 
@@ -119,10 +120,10 @@ class NotifyUsersWorkflowAction extends WorkflowAction {
 	 * @return array
 	 */
 	public function getContextFields(DataObject $target) {
-		$fields = $target->summaryFields();
+		$fields = $target->inheritedDatabaseFields();
 		$result = array();
 
-		foreach($fields as $field) {
+		foreach($fields as $field=>$fieldType) {
 			$result[$field] = $target->$field;
 		}
 
@@ -166,7 +167,7 @@ class NotifyUsersWorkflowAction extends WorkflowAction {
 		$member = _t('NotifyUsersWorkflowAction.MEMBERNOTE',
 			'These fields will be populated from the member that initiates the notification action.');
 		$context = _t('NotifyUsersWorkflowAction.CONTEXTNOTE',
-			'Any summary fields from the workflow target will be available. Additionally, the CMSLink variable will
+			'Any database fields from the workflow target will be available. Additionally, the CMSLink variable will
 			contain a link to edit the workflow target in the CMS (if it is a SiteTree object).');
 		$fieldName = _t('NotifyUsersWorkflowAction.FIELDNAME', 'Field name');
 		$commentHistory = _t('NotifyUsersWorkflowAction.COMMENTHISTORY', 'Comment history up to this notification.');


### PR DESCRIPTION
BUGFIX: set the receivers to the notifying email "To" list, rather than "Bcc" field, populate "Cc" field with current Member's email, leave "Bcc" not used for now.(issue #31)

ENHANCEMENT: given DataObjects' $summery_fields are so varied, and end-user of the module are likely know nothing about what is in $summery_fields, make all viewable fields to be available to notifying email template for easing end user using the module (issue #32)
