### PR TITLE
BUGFIX: Fixed error on TreeDropDownField when selecting user-restriction...

### DIFF
--- a/code/dataobjects/WorkflowTransition.php
+++ b/code/dataobjects/WorkflowTransition.php
@@ -116,7 +116,8 @@ class WorkflowTransition extends DataObject {
 			$typeOptions
 			));
 
-		$fields->addFieldToTab('Root.RestrictToUsers', new TreeMultiselectField('Users', _t('WorkflowDefinition.USERS', 'Restrict to Users'), 'Member'));
+		$members = Member::get();
+		$fields->addFieldToTab('Root.RestrictToUsers', new CheckboxSetField('Users', _t('WorkflowDefinition.USERS', 'Restrict to Users'), $members));
 		$fields->addFieldToTab('Root.RestrictToUsers', new TreeMultiselectField('Groups', _t('WorkflowDefinition.GROUPS', 'Restrict to Groups'), 'Group'));
 
 		$this->extend('updateCMSFields', $fields);


### PR DESCRIPTION
...s in transition dialogue.

Used CheckboxSetField for simplicity to:
a). Reduce reliance on non-framework MultiValueDropdownField (and its ilk)
b). To respect the native security Admin CMS UI for user-administration which also uses checkboxes
