### PR TITLE
BUGFIX: When no effective workflow is enabled, PHP Notice's were thrown ...

### DIFF
--- a/templates/Includes/embargoIntro.ss
+++ b/templates/Includes/embargoIntro.ss
@@ -1,7 +1,9 @@
 
 <p>$INTRO</p>
 <ul>
-	<li>$BULLET_1</li>
+	<% if BULLET_1 %>
+		<li>$BULLET_1</li>
+	<% end_if %>
 	<li>$BULLET_2</li>
 </ul>
 <br/>


### PR DESCRIPTION
...for undefined variable $uth on WorkflowEmbargoExpiryExtension

BUGFIX: WorkflowEmbargoExpiryExtension validation was kicking-in when scheduled dates were not filled-in; implemented getter+setter for effective workflow checking to prevent this
MINOR: Changed intro text on WorkflowEmbargoExpiryExtension depending on effective workflow
