### PR TITLE
BUG:  WorkflowFieldItemController::doSave() when the object is a newly created

### DIFF
--- a/code/formfields/WorkflowFieldItemController.php
+++ b/code/formfields/WorkflowFieldItemController.php
@@ -52,6 +52,10 @@ class WorkflowFieldItemController extends Controller {
 	public function doSave($data, $form) {
 		$record = $form->getRecord();
 
+		if(!$record || !$record->exists()){
+			$record = $this->record;
+		}
+
 		if(!$record->canEdit()) {
 			$this->httpError(403);
 		}


### PR DESCRIPTION
BUG: when a edit form in WorkflowFieldItemController doesn't load a record, when saving it, $form->getRecord() return null, so we need to reassign the the current $record to be the object that the form is saved into.
