### PR TITLE
NEW: default the action that a new transition is created from.

### DIFF
--- a/code/dataobjects/WorkflowTransition.php
+++ b/code/dataobjects/WorkflowTransition.php
@@ -96,13 +96,15 @@ class WorkflowTransition extends DataObject {
 		if ($actions) {
 			$options = $actions->map();
 		}
+
+		$defaultAction = $action?$action->ID:"";
 		
 		$typeOptions = $this->dbObject('Type')->enumValues();
 
 		$fields->addFieldToTab('Root.Main', new DropdownField(
 			'ActionID',
 			_t('WorkflowTransition.ACTION', 'Action'),
-			$options));
+			$options, $defaultAction));
 		$fields->addFieldToTab('Root.Main', new DropdownField(
 			'NextActionID',
 			_t('WorkflowTransition.NEXT_ACTION', 'Next Action'),


### PR DESCRIPTION
When create a transition by click 'add transition' button under an action, the newly created transition should have its "Action" default as the one created from.
