### PR TITLE
Update edit actions to match 3.1 styles

### DIFF
--- a/code/extensions/WorkflowApplicable.php
+++ b/code/extensions/WorkflowApplicable.php
@@ -81,17 +81,16 @@ class WorkflowApplicable extends DataExtension {
 		if (Controller::curr() && Controller::curr()->hasExtension('AdvancedWorkflowExtension')){
 			if ($active) {
 				if ($this->canEditWorkflow()) {
-					$action = new FormAction('updateworkflow', $active->CurrentAction() ? $active->CurrentAction()->Title : _t('WorkflowApplicable.UPDATE_WORKFLOW', 'Update Workflow'));
-					$action->setAttribute('data-icon', 'navigation');
-					$actions->push($action);
+					$action = FormAction::create('updateworkflow', $active->CurrentAction() ? $active->CurrentAction()->Title : _t('WorkflowApplicable.UPDATE_WORKFLOW', 'Update Workflow'))
+						->setAttribute('data-icon', 'navigation');
+					$actions->fieldByName('MajorActions') ? $actions->fieldByName('MajorActions')->push($action) : $actions->push($action);
 				}
 			} else {
 				$effective = $this->workflowService->getDefinitionFor($this->owner);
 				if ($effective && $effective->getInitialAction()) {
-					// we can add an action for starting off the workflow at least
-					$action = new FormAction('startworkflow', $effective->getInitialAction()->Title);
-					$action->setAttribute('data-icon', 'navigation');
-					$actions->push($action);
+					$action = FormAction::create('startworkflow', $effective->getInitialAction()->Title)
+						->setAttribute('data-icon', 'navigation');
+					$actions->fieldByName('MajorActions') ? $actions->fieldByName('MajorActions')->push($action) : $actions->push($action);
 				}
 			}
 		}
@@ -99,17 +98,19 @@ class WorkflowApplicable extends DataExtension {
 	
 	public function updateFrontendActions($actions){
 		$active = $this->workflowService->getWorkflowFor($this->owner);
-
+		
 		if ($active) {
 			if ($this->canEditWorkflow()) {
-				$actions->push(new FormAction('updateworkflow', _t('WorkflowApplicable.UPDATE_WORKFLOW', 'Update Workflow')));
+				$action = FormAction::create('updateworkflow', _t('WorkflowApplicable.UPDATE_WORKFLOW', 'Update Workflow'));
+				$actions->fieldByName('MajorActions') ? $actions->fieldByName('MajorActions')->push($action) : $actions->push($action);
 			}
 		} else {
 			$effective = $this->workflowService->getDefinitionFor($this->owner);
 			if ($effective) {
 				// we can add an action for starting off the workflow at least
 				$initial = $effective->getInitialAction();
-				$actions->push(new FormAction('startworkflow', $initial->Title));
+				$action = FormAction::create('startworkflow', $initial->Title);
+				$actions->fieldByName('MajorActions') ? $actions->fieldByName('MajorActions')->push($action) : $actions->push($action);
 			}
 		}
 	}


### PR DESCRIPTION
Moved the workflow buttons into the major actions group for 3.1

![workflow_im](https://f.cloud.github.com/assets/984753/273909/c4bc92a2-903e-11e2-81cc-dac46e08d544.png)

I think it would be nice for the button to reflect the actual action you are performing [approve, reject, et al] . You could do this in a few different ways. The simplest would be to change the name of the button when the dropdown is changed. A better option would be to remove the dropdown and reference the actions directly. Maybe something like this:

![workflow_3](https://f.cloud.github.com/assets/984753/273861/f760de74-903a-11e2-9cbd-33e91b5d8a91.png)

However, I wouldn't know enough about how workflow works to implement that. And it has it's own problems (approval is itself a major action, and this route makes it appear less important). I do feel that having the two things disconnected as they are now is a bit of a usability issue though.
