### PR TITLE
Replace use of :Negation filter with 3.0 and 3.1 compatible equivalent

### DIFF
--- a/code/actions/NotifyUsersWorkflowAction.php
+++ b/code/actions/NotifyUsersWorkflowAction.php
@@ -40,7 +40,8 @@ class NotifyUsersWorkflowAction extends WorkflowAction {
 				$opts = $templates->map();
 			}
 
-			$fields->addFieldToTab('Root.Main', new DropdownField('ListingTemplateID', $this->fieldLabel('ListingTemplateID'), $opts, '', null, '(choose)'), 'EmailTemplate');
+			$fields->addFieldToTab('Root.Main', $listingTemplateDropdownField = new DropdownField('ListingTemplateID', $this->fieldLabel('ListingTemplateID'), $opts, ''), 'EmailTemplate');
+			$listingTemplateDropdownField->setEmptyString('(choose)');
 		}
 
 		if ($this->ListingTemplateID) {

--- a/code/dataobjects/WorkflowTransition.php
+++ b/code/dataobjects/WorkflowTransition.php
@@ -105,12 +105,11 @@ class WorkflowTransition extends DataObject {
 			'ActionID',
 			_t('WorkflowTransition.ACTION', 'Action'),
 			$options, $defaultAction));
-		$fields->addFieldToTab('Root.Main', new DropdownField(
+		$fields->addFieldToTab('Root.Main', $nextActionDropdownField = new DropdownField(
 			'NextActionID',
 			_t('WorkflowTransition.NEXT_ACTION', 'Next Action'),
-			$options,
-			null, null,
-			_t('WorkflowTransition.SELECTONE', '(Select one)')));
+			$options));
+		$nextActionDropdownField->setEmptyString(_t('WorkflowTransition.SELECTONE', '(Select one)'));
 		$fields->addFieldToTab('Root.Main', new DropdownField(
 			'Type',
 			_t('WorkflowTransition.TYPE', 'Type'),

--- a/code/services/WorkflowService.php
+++ b/code/services/WorkflowService.php
@@ -194,11 +194,15 @@ class WorkflowService implements PermissionProvider {
 		$filter = array('');
 		
 		if (is_array($groupIds)) {
-			$groupInstances = DataList::create('WorkflowInstance')->filter(array('WorkflowStatus:Negation' => 'Complete',  'Group.ID:ExactMatchMulti' => $groupIds));
+			$groupInstances = DataList::create('WorkflowInstance')
+				->filter(array('Group.ID:ExactMatchMulti' => $groupIds))
+				->where('"WorkflowStatus" != \'Complete\'');
 		}
 
-		$userInstances = DataList::create('WorkflowInstance')->filter(array('WorkflowStatus:Negation' => 'Complete', 'Users.ID:ExactMatch' => $user->ID));
-		
+		$userInstances = DataList::create('WorkflowInstance')
+			->filter(array('Users.ID:ExactMatch' => $user->ID))
+			->where('"WorkflowStatus" != \'Complete\'');
+
 		if ($userInstances) {
 			$userInstances = $userInstances->toArray();
 		} else {
@@ -223,9 +227,11 @@ class WorkflowService implements PermissionProvider {
 	 * @return DataList $userInstances
 	 */
 	public function userPendingItems(Member $user) {
-		$filter = array('WorkflowStatus:Negation' => 'Complete');
 		// Don't restrict anything for ADMIN users
-		$userInstances = DataList::create('WorkflowInstance')->filter($filter)->sort('LastEdited DESC');
+		$userInstances = DataList::create('WorkflowInstance')
+			->where('"WorkflowStatus" != \'Complete\'')
+			->sort('LastEdited DESC');
+
 		if(Permission::checkMember($user, 'ADMIN')) {
 			return $userInstances;
 		}
@@ -248,12 +254,14 @@ class WorkflowService implements PermissionProvider {
 	 * @return DataList $userInstances
 	 */
 	public function userSubmittedItems(Member $user) {
-		$filter = array('WorkflowStatus:Negation' => 'Complete', 'InitiatorID' => $user->ID);
-		// Don't restrict anything for ADMIN users
-		if(Permission::checkMember($user, 'ADMIN')) {
-			array_pop($filter);
+		$userInstances = DataList::create('WorkflowInstance')
+			->where('"WorkflowStatus" != \'Complete\'')
+			->sort('LastEdited DESC');
+
+		// Restrict the user if they're not an ADMIN.
+		if(!Permission::checkMember($user, 'ADMIN')) {
+			$userInstances = $userInstances->filter('InitiatorID:ExactMatch', $user->ID);
 		}
-		$userInstances = DataList::create('WorkflowInstance')->filter($filter)->sort('LastEdited DESC');
 
 		return $userInstances;
 	}


### PR DESCRIPTION
This is a replacement for pull request #92. This now works with 3.0 and 3.1, as it uses a simpler `where()` call to check the WorkflowStatus as not complete instead.
