### PR TITLE
FIX: Fixed action sort bug. Added CSRF token (SecurityID) to sort request

### DIFF
--- a/javascript/WorkflowField.js
+++ b/javascript/WorkflowField.js
@@ -70,7 +70,8 @@ jQuery.entwine("workflow", function($) {
 
 					var data = {
 						"id[]":  ids.get(),
-						"class": "WorkflowAction"
+						"class": "WorkflowAction",
+						"SecurityID": field.data("securityid")
 					};
 
 					field.loading();


### PR DESCRIPTION
The sortable implementation on the workflow action sort was missing the CSRF token. I've added this to the JS.
