### PR TITLE
BUG Selecting one of the deletion icons on a transition/action displayed...

### DIFF
--- a/code/admin/AdvancedWorkflowAdmin.php
+++ b/code/admin/AdvancedWorkflowAdmin.php
@@ -31,6 +31,16 @@ class AdvancedWorkflowAdmin extends ModelAdmin {
 	 * @var WorkflowService
 	 */
 	public $workflowService;
+	
+	/**
+	 * Initialise javascript translation files
+	 * 
+	 * @return void
+	 */
+	public function init() {
+		parent::init();
+		Requirements::add_i18n_javascript('advancedworkflow/javascript/lang');
+	}	
 
 	/*
 	 * Shows up to x2 GridFields for Pending and Submitted items, dependent upon the current CMS user and that user's permissions


### PR DESCRIPTION
BUG Selecting one of the deletion icons on a transition/action displayed an empty JS confirmation dialogue. Fixes #122
