### PR TITLE
BUG Fixes #125. Error viewing WorkflowInstance in GridField.

### DIFF
--- a/code/dataobjects/WorkflowInstance.php
+++ b/code/dataobjects/WorkflowInstance.php
@@ -351,8 +351,22 @@ class WorkflowInstance extends DataObject {
 		return $list;
 	}
 
+	/**
+	 * 
+	 * @param \Member $member
+	 * @return boolean
+	 */
 	public function canView($member=null) {
-		return $this->userHasAccess($member);
+		$hasAccess = $this->userHasAccess($member);
+		/*
+		 * If the next action is an AssignUsersToWorkflowAction, its execute() method resets all user+group relations.
+		 * So the current user no-longer has permission to view this item in a PendingObjects Gridfield, even though she enacted it.
+		 * This is not the ideal solution, as the user who has issues is not always going to be the initiator
+		 */
+		if(!$hasAccess && ($this->InitiatorID == Member::currentUserID())) {
+			return true;
+		}
+		return $hasAccess;
 	}
 	public function canEdit($member=null) {
 		return $this->userHasAccess($member);


### PR DESCRIPTION
When the next action is an AssignUsersToWorkflowAction, Member relations
are wiped. But users on the previous action still need to see the
WorkflowInstance in the PendingObjects GridField after editing+saving.
