### PR TITLE
BUG Builds on 6e34f65314 (ref issue #125)

### DIFF
--- a/code/actions/AssignUsersToWorkflowAction.php
+++ b/code/actions/AssignUsersToWorkflowAction.php
@@ -61,4 +61,32 @@ SQL;
 			'AssignInitiator'	=> _t('AssignUsersToWorkflowAction.INITIATOR', 'Assign Initiator'),
 		));
 	}
+	
+	/**
+	 * Returns a set of all Members that are assigned to this WorkflowAction subclass, either directly or via a group.
+	 *
+	 * @return ArrayList
+	 */
+	public function getAssignedMembers() {
+		$members = $this->Users();
+		$groups  = $this->Groups();
+		
+		// Can't merge instances of DataList so convert to something where we can
+		$_members = ArrayList::create();
+		$members->each(function($item) use(&$_members) {
+			$_members->push($item);
+		});
+		
+		$_groups = ArrayList::create();
+		$groups->each(function($item) use(&$_groups) {
+			$_groups->push($item);
+		});		
+
+		foreach($_groups as $group) {
+			$_members->merge($group->Members());
+		}
+
+		$_members->removeDuplicates();
+		return $_members;
+	}	
 }

--- a/tests/WorkflowInstanceTest.php
+++ b/tests/WorkflowInstanceTest.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * Tests for the workflow engine.
+ *
+ * @author     marcus@silverstripe.com.au
+ * @license    BSD License (http://silverstripe.org/bsd-license/)
+ * @package    advancedworkflow
+ * @subpackage tests
+ */
+class WorkflowInstanceTest extends SapphireTest {
+	
+	/**
+	 *
+	 * @var string
+	 */
+	public static $fixture_file = 'advancedworkflow/tests/useractioninstancehistory.yml';
+	
+	/**
+	 * 
+	 * @var Member
+	 */
+	protected $currentMember;
+	
+	/**
+	 * 
+	 */
+	public function setUp() {
+		parent::setUp();
+		$this->currentMember = $this->objFromFixture('Member', 'ApproverMember01');
+	}
+
+	/**
+	 * Tests WorkflowInstance#getMostRecentActionForUser()
+	 */
+	public function testGetMostRecentActionForUser() {
+	
+		// Single, AssignUsersToWorkflowAction in "History"
+		$history01 = $this->objFromFixture('WorkflowInstance', 'WorkflowInstance01');
+		$mostRecentActionForUser01 = $history01->getMostRecentActionForUser($this->currentMember);
+		$this->assertInstanceOf('WorkflowActionInstance', $mostRecentActionForUser01, 'Asserts the correct ClassName is retured #1');
+		$this->assertEquals('Assign', $mostRecentActionForUser01->BaseAction()->Title, 'Asserts the correct BaseAction is retured #1');
+		
+		// No AssignUsersToWorkflowAction found with Member's related Group in "History"
+		$history02 = $this->objFromFixture('WorkflowInstance', 'WorkflowInstance02');
+		$mostRecentActionForUser02 = $history02->getMostRecentActionForUser($this->currentMember);
+		$this->assertFalse($mostRecentActionForUser02, 'Asserts false is returned because no WorkflowActionInstance was found');
+		
+		// Multiple AssignUsersToWorkflowAction in "History", only one with Group relations
+		$history03 = $this->objFromFixture('WorkflowInstance', 'WorkflowInstance03');
+		$mostRecentActionForUser03 = $history03->getMostRecentActionForUser($this->currentMember);
+		$this->assertInstanceOf('WorkflowActionInstance', $mostRecentActionForUser03, 'Asserts the correct ClassName is retured #2');
+		$this->assertEquals('Assign', $mostRecentActionForUser03->BaseAction()->Title, 'Asserts the correct BaseAction is retured #2');
+		
+		// Multiple AssignUsersToWorkflowAction in "History", both with Group relations
+		$history04 = $this->objFromFixture('WorkflowInstance', 'WorkflowInstance04');
+		$mostRecentActionForUser04 = $history04->getMostRecentActionForUser($this->currentMember);
+		$this->assertInstanceOf('WorkflowActionInstance', $mostRecentActionForUser04, 'Asserts the correct ClassName is retured #3');
+		$this->assertEquals('Assigned Again', $mostRecentActionForUser04->BaseAction()->Title, 'Asserts the correct BaseAction is retured #3');
+		
+		// Multiple AssignUsersToWorkflowAction in "History", one with Group relations
+		$history05 = $this->objFromFixture('WorkflowInstance', 'WorkflowInstance05');
+		$mostRecentActionForUser05 = $history05->getMostRecentActionForUser($this->currentMember);
+		$this->assertInstanceOf('WorkflowActionInstance', $mostRecentActionForUser05, 'Asserts the correct ClassName is retured #4');
+		$this->assertEquals('Assigned Me', $mostRecentActionForUser05->BaseAction()->Title, 'Asserts the correct BaseAction is retured #4');
+	}
+	
+	/**
+	 * Tests WorkflowInstance#canView()
+	 */
+	public function testCanView() {
+		// Single, AssignUsersToWorkflowAction in "History"
+		$history01 = $this->objFromFixture('WorkflowInstance', 'WorkflowInstance01');
+		$this->assertTrue($history01->canView($this->currentMember));
+		
+		// No AssignUsersToWorkflowAction found with Member's related Group in "History"
+		$history02 = $this->objFromFixture('WorkflowInstance', 'WorkflowInstance02');
+		$this->assertFalse($history02->canView($this->currentMember));
+		
+		// Multiple AssignUsersToWorkflowAction in "History", only one with Group relations
+		$history03 = $this->objFromFixture('WorkflowInstance', 'WorkflowInstance03');
+		$this->assertTrue($history03->canView($this->currentMember));	
+		
+		// Multiple AssignUsersToWorkflowAction in "History", both with Group relations
+		$history04 = $this->objFromFixture('WorkflowInstance', 'WorkflowInstance04');
+		$this->assertTrue($history04->canView($this->currentMember));	
+		
+		// Multiple AssignUsersToWorkflowAction in "History"
+		$history05 = $this->objFromFixture('WorkflowInstance', 'WorkflowInstance05');
+		$this->assertTrue($history05->canView($this->currentMember));	
+	}
+
+}

--- a/tests/useractioninstancehistory.yml
+++ b/tests/useractioninstancehistory.yml
@@ -1,0 +1,143 @@
+#
+# Models the first part of the default _config YML template as a fixture as though it's been run and is part way through
+#
+WorkflowTransition:
+  Transition01:
+    Title: notify
+  Transition02:
+    Title: approval
+  Transition03:
+    Title: Approve
+  Transition04:
+    Title: Reject
+    
+Member:
+  ApproverMember01:
+    ID: 1
+    FirstName: General
+    Surname: Approver
+    Email: g.approver@localhost
+  
+Group:
+  BaseAction01Group:
+    Title: Approvers
+    Members: =>Member.ApproverMember01
+
+AssignUsersToWorkflowAction:
+  BaseAction01:
+    Title: Assign
+    Transitions: =>WorkflowTransition.Transition01
+    Groups: =>Group.BaseAction01Group
+  BaseAction011:
+    Title: 'Another Assignment'
+    Transitions: =>WorkflowTransition.Transition01
+  BaseAction012:
+    Title: 'Assigned Again'
+    Transitions: =>WorkflowTransition.Transition01
+    Groups: =>Group.BaseAction01Group
+  BaseAction013:
+    Title: 'Assigned Me'
+    Transitions: =>WorkflowTransition.Transition01
+    Groups: =>Group.BaseAction01Group
+  BaseAction014:
+    Title: 'Not Re-Assigned Me'
+    Transitions: =>WorkflowTransition.Transition01
+NotifyUsersWorkflowAction:
+  BaseAction02:
+    Title: 'Notify users'
+    Transitions: =>WorkflowTransition.Transition02
+  BaseAction021:
+    Title: 'Notify users'
+    Transitions: =>WorkflowTransition.Transition02   
+SimpleApprovalWorkflowAction:
+  BaseAction03:
+    Title: Approval
+    Transitions: =>WorkflowTransition.Transition03,=>WorkflowTransition.Transition04
+  BaseAction031:
+    Title: Approval
+    Transitions: =>WorkflowTransition.Transition03,=>WorkflowTransition.Transition04    
+ 
+WorkflowActionInstance:
+  ActionInstance01:
+    Created: '2014-02-17 16:15:00'
+    Finished: 1
+    BaseAction: =>AssignUsersToWorkflowAction.BaseAction01
+  ActionInstance02:
+    Created: '2014-02-17 16:15:01'
+    Finished: 1
+    BaseAction: =>NotifyUsersWorkflowAction.BaseAction02
+  ActionInstance03:
+    Created: '2014-02-17 16:15:02'      
+    Finished: 1
+    BaseAction: =>SimpleApprovalWorkflowAction.BaseAction03
+  ActionInstance04:
+    Created: '2014-02-17 16:14:59'
+    Finished: 1
+    BaseAction: =>AssignUsersToWorkflowAction.BaseAction011
+  ActionInstance05:
+    Created: '2014-02-17 16:15:00'      
+    Finished: 1
+    BaseAction: =>AssignUsersToWorkflowAction.BaseAction01
+  ActionInstance06:
+    Created: '2014-02-17 16:15:01'      
+    Finished: 1
+    BaseAction: =>NotifyUsersWorkflowAction.BaseAction02
+  ActionInstance07:
+    Created: '2014-02-17 16:15:02'      
+    Finished: 1
+    BaseAction: =>SimpleApprovalWorkflowAction.BaseAction03
+  ActionInstance08:
+    Created: '2014-02-17 16:15:03'      
+    Finished: 1
+    BaseAction: =>AssignUsersToWorkflowAction.BaseAction011 
+  ActionInstance09:
+    Created: '2014-02-17 16:15:00'
+    Finished: 1
+    BaseAction: =>AssignUsersToWorkflowAction.BaseAction01
+  ActionInstance10:
+    Created: '2014-02-17 16:15:01'
+    Finished: 1
+    BaseAction: =>NotifyUsersWorkflowAction.BaseAction02
+  ActionInstance11:
+    Created: '2014-02-17 16:15:02'
+    Finished: 1
+    BaseAction: =>AssignUsersToWorkflowAction.BaseAction012
+  ActionInstance12:
+    Created: '2014-02-17 16:15:00'
+    Finished: 1
+    BaseAction: =>AssignUsersToWorkflowAction.BaseAction013
+  ActionInstance13:
+    Created: '2014-02-17 16:15:01'
+    Finished: 1
+    BaseAction: =>NotifyUsersWorkflowAction.BaseAction021
+  ActionInstance14:
+    Created: '2014-02-17 16:15:02'      
+    Finished: 1
+    BaseAction: =>SimpleApprovalWorkflowAction.BaseAction031  
+  ActionInstance15:
+    Created: '2014-02-17 16:15:03'      
+    Finished: 1
+    BaseAction: =>AssignUsersToWorkflowAction.BaseAction014   
+  
+WorkflowInstance:
+  WorkflowInstance01:
+    Title: 'Test WorkflowInstance 01'
+    WorkflowStatus: Paused
+    Actions: =>WorkflowActionInstance.ActionInstance01,=>WorkflowActionInstance.ActionInstance02,=>WorkflowActionInstance.ActionInstance03
+  WorkflowInstance02:
+    Title: 'Test WorkflowInstance 02'
+    WorkflowStatus: Paused
+    Actions: =>WorkflowActionInstance.ActionInstance04,=>WorkflowActionInstance.ActionInstance02,=>WorkflowActionInstance.ActionInstance03
+  WorkflowInstance03:
+    Title: 'Test WorkflowInstance 03'
+    WorkflowStatus: Paused
+    Actions: =>WorkflowActionInstance.ActionInstance05,=>WorkflowActionInstance.ActionInstance06,=>WorkflowActionInstance.ActionInstance07,=>WorkflowActionInstance.ActionInstance08
+  WorkflowInstance04:
+    Title: 'Test WorkflowInstance 04'
+    WorkflowStatus: Paused
+    Actions: =>WorkflowActionInstance.ActionInstance09,=>WorkflowActionInstance.ActionInstance10,=>WorkflowActionInstance.ActionInstance11
+  WorkflowInstance05:
+    Title: 'Test WorkflowInstance 05'
+    WorkflowStatus: Paused
+    Actions: =>WorkflowActionInstance.ActionInstance12,=>WorkflowActionInstance.ActionInstance13,=>WorkflowActionInstance.ActionInstance14,=>WorkflowActionInstance.ActionInstance15
+ 


### PR DESCRIPTION
Modified logic to determine if 1 of last 2 actions were run by
a user on a WorkflowInstance. If user is normally without canView()
on a WorkflowInstance at this point, ensures she can view it.

Added supporting tests also.
- UserX is assigned action from a AssignUsersToWorkflowAction
- UserX runs a transition leading to another AssignUsersToWorkflowAction
- At this point, user+groups are reset on the current WorkflowInstance
- UserX redirected to a GridField with a “Forbidden” error as a result
