### PR TITLE
BUG Fixes #133. Disable click on SubmittedObject's GridField rows.

### DIFF
--- a/code/admin/AdvancedWorkflowAdmin.php
+++ b/code/admin/AdvancedWorkflowAdmin.php
@@ -40,6 +40,8 @@ class AdvancedWorkflowAdmin extends ModelAdmin {
 	public function init() {
 		parent::init();
 		Requirements::add_i18n_javascript('advancedworkflow/javascript/lang');
+		Requirements::javascript('advancedworkflow/javascript/WorkflowGridField.js');
+		Requirements::css('advancedworkflow/css/WorkflowGridField.css');
 	}	
 
 	/*
@@ -116,6 +118,8 @@ class AdvancedWorkflowAdmin extends ModelAdmin {
 			$dataColumns->setDisplayFields($displayFields);
 
 			$formFieldBottom->setForm($form);
+			$formFieldBottom->getConfig()->removeComponentsByType('GridFieldEditButton');
+			$formFieldBottom->getConfig()->addComponent(new GridFieldWorkflowRestrictedEditButton());
 			$form->Fields()->insertBefore($formFieldBottom, 'WorkflowDefinition');
 		}
 		

--- a/code/forms/gridfield/GridFieldWorkflowRestrictedEditButton.php
+++ b/code/forms/gridfield/GridFieldWorkflowRestrictedEditButton.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ *
+ * @package advancedworkflow
+ */
+class GridFieldWorkflowRestrictedEditButton implements GridField_ColumnProvider {
+	
+	/**
+	 * Add a column
+	 * 
+	 * @param type $gridField
+	 * @param array $columns 
+	 */
+	public function augmentColumns($gridField, &$columns) {
+		if(!in_array('Actions', $columns))
+			$columns[] = 'Actions';
+	}
+	
+	/**
+	 * Append a 'disabled' CSS class to GridField rows whose WorkflowInstance records are not viewable/editable
+	 * by the current user. 
+	 * 
+	 * This is used to visually "grey out" records and it's leveraged in some overriding JavaScript, to maintain an ability
+	 * to click the target object's hyperlink.
+	 *
+	 * @param GridField $gridField
+	 * @param DataObject $record
+	 * @param string $columnName
+	 * @return array
+	 */
+	public function getColumnAttributes($gridField, $record, $columnName) {
+		$defaultAtts = array('class' => 'col-buttons');
+		if($record instanceof WorkflowInstance) {
+			if(!$record->getAssignedMembers()->find('ID', Member::currentUserID())) {
+				$atts['class'] = $defaultAtts['class'].' disabled';
+				return $atts;
+			}
+			return $defaultAtts;
+		}
+		return $defaultAtts;
+	}
+	
+	/**
+	 * Add the title 
+	 * 
+	 * @param GridField $gridField
+	 * @param string $columnName
+	 * @return array
+	 */
+	public function getColumnMetadata($gridField, $columnName) {
+		if($columnName == 'Actions') {
+			return array('title' => '');
+		}
+	}
+	
+	/**
+	 * Which columns are handled by this component
+	 * 
+	 * @param type $gridField
+	 * @return type 
+	 */
+	public function getColumnsHandled($gridField) {
+		return array('Actions');
+	}
+	
+	/**
+	 * @param GridField $gridField
+	 * @param DataObject $record
+	 * @param string $columnName
+	 *
+	 * @return string - the HTML for the column 
+	 */
+	public function getColumnContent($gridField, $record, $columnName) {
+		$data = new ArrayData(array(
+			'Link' => Controller::join_links($gridField->Link('item'), $record->ID, 'edit')
+		));
+		return $data->renderWith('GridFieldEditButton');
+	}
+}

--- a/css/WorkflowGridField.css
+++ b/css/WorkflowGridField.css
@@ -1,0 +1,1 @@
+.ss-gridfield .ss-gridfield-item.disabled a.action { opacity: 0.35; filter: Alpha(Opacity=35); cursor: default; }

--- a/javascript/WorkflowGridField.js
+++ b/javascript/WorkflowGridField.js
@@ -1,0 +1,39 @@
+(function($) {
+
+	$.entwine('ss', function($) {
+		
+		// Disable clicking on each disabled table-row.
+		$('.ss-gridfield .ss-gridfield-item').entwine({
+			onmatch: function(e) {
+				var ele = $(this);
+				var row = ele.closest('tr');
+				row.on('click', function(e) {
+					/*
+					 * Prevent a precursor POST to gridfield record URLs (all GridFields) when clicking on target-object's
+					 * hyperlinks, which results in a 404.
+					 */
+					e.stopPropagation();
+				});
+
+				if(ele.find('.col-buttons.disabled').length) {
+					row
+						.addClass('disabled')
+						// Disable any actions on the <tr> and edit icons, but do allow for target-object's hyperlink.
+						.on('click', function(e) {
+							return (e.target.nodeName === 'A' && e.target.className.match(/edit-link/) === null);
+						});
+						ele.find('a.edit-link').attr('title', '');
+				}
+			}
+		});
+		
+		// Override GridField's method of providing cursor styles on hover.
+		$('.AdvancedWorkflowAdmin .ss-gridfield-item.disabled').entwine({
+			onmouseover: function() {
+				this.css('cursor', 'default');
+			}
+		});	
+		
+	});
+	
+}(jQuery));

--- a/scss/WorkflowGridField.scss
+++ b/scss/WorkflowGridField.scss
@@ -1,0 +1,11 @@
+.ss-gridfield {
+	.ss-gridfield-item {
+		&.disabled {
+			a.action {
+				opacity: 0.35;
+				filter: Alpha(Opacity=35);
+				cursor: default;
+			}
+		}
+	}
+}


### PR DESCRIPTION
WorkflowInstances may not belong to users when passed to an
AssignUsersToWorkflowAction. Therefore we prevent CMS errors when
table rows & edit icons are clicked in "SubmittedObjects" GridField.
- Additionally, we visually indicate these records as 'disabled'.
- Also fixes AJAX 404 before redirection when clicking hyperlink.
