### PR TITLE
BUG Fixes #144. Users with limited permissions can delete workflows.

### DIFF
--- a/code/dataobjects/WorkflowAction.php
+++ b/code/dataobjects/WorkflowAction.php
@@ -78,6 +78,43 @@ class WorkflowAction extends DataObject {
 	public function canPublishTarget(DataObject $target) {
 		return null;
 	}
+	
+	/**
+	 * Allows users who have permission to create a WorkflowDefinition, to create actions on it too.
+	 * 
+	 * @param  Member $member
+	 * @return bool
+	 */
+	public function canCreate($member = null) {
+		return $this->WorkflowDef()->canCreate($member);
+	}
+	
+	/**
+	 * @param  Member $member
+	 * @return bool
+	 */	
+	public function canEdit($member = null) {
+		return $this->canCreate($member);
+	}
+	
+	/**
+	 * @param  Member $member
+	 * @return bool
+	 */		
+	public function canDelete($member = null) {
+		return $this->canCreate($member);
+	}
+	
+	/*
+	 * If there is only a single action defined for a workflow, there's no sense
+	 * in allowing users to add a transition to it (and causing errors).
+	 * Hide the "Add Transition" button in this case
+	 *
+	 * @return boolean true if we should disable the button, false otherwise
+	 */
+	public function canAddTransition() {
+		return ($this->WorkflowDef()->numChildren() >1);
+	}	
 
 	/**
 	 * Gets an object that is used for saving the actual state of things during
@@ -214,41 +251,5 @@ class WorkflowAction extends DataObject {
 
 	public function Icon() {
 		return $this->stat('icon');
-	}
-
-	/*
-	 * If there is only a single action defined for a workflow, there is no sense in allowing users to add a transition to it (and causing errors).
-	 * Hide the "Add Transition" button in this case
-	 *
-	 * @return boolean true if we should disable the button, false otherwise
-	 */
-	public function disableButtonAddTransition() {
-		if($this->WorkflowDef()->numChildren() == 1 || $this->disableButton()) {
-			return true;
-		}
-		return false;
-	}
-
-	/*
-	 * Returns true if a button should be disabled due to a low level of user-permissions on the current WorkflowAction.
-	 * Ultimately relies on WorkflowInstance->userHasAccess() to decide if a user has permission to edit a transition or action, on their workflowInstance.
-	 *
-	 * @todo Should we be taking account of $this->AllowEditing()??
-	 * @todo Might this be better defined on WorkflowService? There is an almost identical method defined on WorkflowTransition
-	 *
-	 * @param Member $member
-	 * @return boolean
-	 */
-	public function disableButton($member = null) {
-		if(Permission::checkMember($member, 'ADMIN')) {
-			return false;
-		}
-		if(!$member) {
-			$member = Member::currentUser();
-		}
-		if(!$this->WorkflowDef()->canEdit($member)) {
-			return true; // disable
-		}
-		return false;
 	}
 }

--- a/code/dataobjects/WorkflowDefinition.php
+++ b/code/dataobjects/WorkflowDefinition.php
@@ -286,6 +286,11 @@ class WorkflowDefinition extends DataObject {
 		self::$workflow_defs = $workflow_defs->map()->toArray();
 	}
 
+	/**
+	 * 
+	 * @param Member $member
+	 * @return boolean
+	 */
 	public function canCreate($member=null) {
 		if (is_null($member)) {
 			if (!Member::currentUserID()) {
@@ -293,17 +298,34 @@ class WorkflowDefinition extends DataObject {
 			}
 			$member = Member::currentUser();
 		}
-
 		return Permission::checkMember($member, 'CREATE_WORKFLOW');
 	}
+	
+	/**
+	 * 
+	 * @param Member $member
+	 * @return boolean
+	 */	
 	public function canView($member=null) {
 		return $this->userHasAccess($member);
 	}
+	
+	/**
+	 * 
+	 * @param Member $member
+	 * @return boolean
+	 */	
 	public function canEdit($member=null) {
-		return $this->userHasAccess($member);
+		return $this->canCreate($member);
 	}
+	
+	/**
+	 * 
+	 * @param Member $member
+	 * @return boolean
+	 */	
 	public function canDelete($member=null) {
-		return $this->userHasAccess($member);
+		return $this->canCreate($member);
 	}
 
 	/**

--- a/code/dataobjects/WorkflowTransition.php
+++ b/code/dataobjects/WorkflowTransition.php
@@ -185,9 +185,33 @@ class WorkflowTransition extends DataObject {
 		}else{
 			return $return;
 		}
-
-
 	}
+	
+	/**
+	 * Allows users who have permission to create a WorkflowDefinition, to create actions on it too.
+	 * 
+	 * @param  Member $member
+	 * @return bool
+	 */
+	public function canCreate($member = null) {
+		return $this->Action()->WorkflowDef()->canCreate($member);
+	}
+	
+	/**
+	 * @param  Member $member
+	 * @return bool
+	 */	
+	public function canEdit($member = null) {
+		return $this->canCreate($member);
+	}
+	
+	/**
+	 * @param  Member $member
+	 * @return bool
+	 */		
+	public function canDelete($member = null) {
+		return $this->canCreate($member);
+	}	
 
 	/**
 	 * Returns a set of all Members that are assigned to this transition, either directly or via a group.
@@ -229,27 +253,5 @@ class WorkflowTransition extends DataObject {
 				'A transition cannot lead back to its parent action.');
 		}
 		return self::$extendedMethodReturn;
-	}
-
-	/*
-	 * Returns true if a button should be disabled due to a low level of user-permissions on the current WorkflowTransition.
-	 * Ultimately relies on WorkflowInstance->userHasAccess() to decide if a user has permission to edit a transition or action, on their workflowInstance.
-	 *
-	 * @todo Might this be better defined on WorkflowService? There is an almost identical method defined on WorkflowTransition
-	 *
-	 * @param Member $member
-	 * @return boolean
-	 */
-	public function disableButton($member = null) {
-		if(Permission::checkMember($member, 'ADMIN')) {
-			return false;
-		}
-		if(!$member) {
-			$member = Member::currentUser();
-		}
-		if(!$this->Action()->WorkflowDef()->canEdit($member)) {
-			return true; // disable
-		}
-		return false;
 	}
 }

--- a/templates/WorkflowField.ss
+++ b/templates/WorkflowField.ss
@@ -28,13 +28,13 @@
 					<h4>$Title</h4>
 
 					<div class="workflow-field-action-buttons">
-						<a class="ss-ui-button workflow-field-open-dialog<% if $disableButton %> workflow-field-action-disabled<% end_if %>" href="$Top.ActionLink('item',$ID,'edit')" data-icon="pencil">
+						<a class="ss-ui-button workflow-field-open-dialog<% if $canEdit %><% else %> workflow-field-action-disabled<% end_if %>" href="$Top.ActionLink('item',$ID,'edit')" data-icon="pencil">
 							<%t WorkflowField.EditAction "Edit" %>
 						</a>
-						<a class="ss-ui-button workflow-field-open-dialog<% if $disableButtonAddTransition %> workflow-field-action-disabled<% end_if %>" href="$Top.TransitionLink('new',$ID,'edit')" data-icon="chain--arrow">
+						<a class="ss-ui-button workflow-field-open-dialog <% if $canAddTransition %><% else %> workflow-field-action-disabled<% end_if %>" href="$Top.TransitionLink('new',$ID,'edit')" data-icon="chain--arrow">
 							<%t WorkflowField.AddTransitionAction "Add Transition" %>
 						</a>
-						<a href="$Top.ActionLink('item',$ID,'delete')" data-securityid="$SecurityID" class="ss-ui-button workflow-field-delete<% if $disableButton %> workflow-field-action-disabled<% end_if %>" data-icon="cross-circle">
+						<a href="$Top.ActionLink('item',$ID,'delete')" data-securityid="$SecurityID" class="ss-ui-button workflow-field-delete<% if $canDelete %><% else %> workflow-field-action-disabled<% end_if %>" data-icon="cross-circle">
 							<%t WorkflowField.DeleteAction "Delete" %>
 						</a>
 					</div>
@@ -51,10 +51,10 @@
 									<span class="ui-icon btn-icon-chain-small"></span>
 									<span class="next-title">$NextAction.Title</span>
 								</div>
-								<a href="$Top.TransitionLink('item',$ID,'edit')" class="ui-icon btn-icon-pencil workflow-field-open-dialog<% if $disableButton %> workflow-field-action-disabled<% end_if %>">
+								<a href="$Top.TransitionLink('item',$ID,'edit')" class="ui-icon btn-icon-pencil workflow-field-open-dialog<% if $canEdit %><% else %> workflow-field-action-disabled<% end_if %>">
 									<%t WorkflowField.EditAction "Edit" %>
 								</a>
-								<a href="$Top.TransitionLink('item',$ID,'delete')" data-securityid="$SecurityID" class="ui-icon btn-icon-cross-circle workflow-field-delete<% if $disableButton %> workflow-field-action-disabled<% end_if %>">
+								<a href="$Top.TransitionLink('item',$ID,'delete')" data-securityid="$SecurityID" class="ui-icon btn-icon-cross-circle workflow-field-delete<% if $canDelete %><% else %> workflow-field-action-disabled<% end_if %>">
 									<%t WorkflowField.DeleteAction "Delete" %>
 								</a>
 							</li>

--- a/tests/WorkflowPermissionsTest.php
+++ b/tests/WorkflowPermissionsTest.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Tests for permissions on all Workflow Objects.
+ * These will obviousely need to be modified should additional workflow permissions come online.
+ *
+ * @author     russell@silverstripe.com
+ * @license    BSD License (http://silverstripe.org/bsd-license/)
+ * @package    advancedworkflow
+ * @subpackage tests
+ */
+class WorkflowPermissionsTest extends SapphireTest {
+
+	/**
+	 * @var string
+	 */
+	public static $fixture_file = 'advancedworkflow/tests/workflowpermissions.yml';
+	
+	/**
+	 * Tests whether members with differing permissions, should be able to create & edit WorkflowDefinitions
+	 */
+	public function testWorkflowDefinitionCanPerms() {
+		// Very limited perms. No create.
+		$this->logInWithPermission('CMS_ACCESS_AdvancedWorkflowAdmin');
+		$workflowdef = $this->objFromFixture('WorkflowDefinition', 'no-actions');
+		$this->assertFalse($workflowdef->canCreate());
+		
+		// Limited perms. No create.
+		$this->logInWithPermission('VIEW_ACTIVE_WORKFLOWS');
+		$workflowdef = $this->objFromFixture('WorkflowDefinition', 'no-actions');
+		$this->assertFalse($workflowdef->canCreate());
+		
+		// Has perms. Can create.
+		$this->logInWithPermission('CREATE_WORKFLOW');
+		$workflowdef = $this->objFromFixture('WorkflowDefinition', 'no-actions');
+		$this->assertTrue($workflowdef->canCreate());			
+	}
+	
+	/**
+	 * Tests whether members with differing permissions, should be able to create & edit WorkflowActions
+	 */
+	public function testWorkflowActionCanPerms() {
+		// Very limited perms. No create.
+		$this->logInWithPermission('CMS_ACCESS_AdvancedWorkflowAdmin');
+		$workflowdef = $this->objFromFixture('WorkflowDefinition', 'with-actions');
+		$this->assertFalse($workflowdef->Actions()->first()->canCreate());
+		$this->assertFalse($workflowdef->Actions()->first()->canEdit());
+		$this->assertFalse($workflowdef->Actions()->first()->canDelete());
+		
+		// Limited perms. No create.
+		$this->logInWithPermission('VIEW_ACTIVE_WORKFLOWS');
+		$workflowdef = $this->objFromFixture('WorkflowDefinition', 'with-actions');
+		$this->assertFalse($workflowdef->Actions()->first()->canCreate());
+		$this->assertFalse($workflowdef->Actions()->first()->canCreate());
+		$this->assertFalse($workflowdef->Actions()->first()->canDelete());
+		
+		// Has perms. Can create.
+		$this->logInWithPermission('CREATE_WORKFLOW');
+		$workflowdef = $this->objFromFixture('WorkflowDefinition', 'with-actions');
+		$this->assertTrue($workflowdef->Actions()->first()->canCreate());
+		$this->assertTrue($workflowdef->Actions()->first()->canEdit());	
+		$this->assertTrue($workflowdef->Actions()->first()->canDelete());
+	}	
+	
+	/**
+	 * Tests whether members with differing permissions, should be able to create & edit WorkflowActions
+	 */
+	public function testWorkflowTransitionPerms() {
+		// Very limited perms. No create.
+		$this->logInWithPermission('CMS_ACCESS_AdvancedWorkflowAdmin');
+		$workflowdef = $this->objFromFixture('WorkflowDefinition', 'with-actions-and-transitions');
+		$this->assertFalse($workflowdef->Actions()->first()->Transitions()->first()->canCreate());
+		$this->assertFalse($workflowdef->Actions()->first()->Transitions()->first()->canEdit());
+		$this->assertFalse($workflowdef->Actions()->first()->Transitions()->first()->canDelete());
+		
+		// Limited perms. No create.
+		$this->logInWithPermission('VIEW_ACTIVE_WORKFLOWS');
+		$workflowdef = $this->objFromFixture('WorkflowDefinition', 'with-actions-and-transitions');
+		$this->assertFalse($workflowdef->Actions()->first()->Transitions()->first()->canCreate()); 
+		$this->assertFalse($workflowdef->Actions()->first()->Transitions()->first()->canEdit()); 
+		$this->assertFalse($workflowdef->Actions()->first()->Transitions()->first()->canDelete());
+		
+		// Has perms. Can create.
+		$this->logInWithPermission('CREATE_WORKFLOW');
+		$workflowdef = $this->objFromFixture('WorkflowDefinition', 'with-actions-and-transitions');
+		$this->assertTrue($workflowdef->Actions()->first()->Transitions()->first()->canCreate());
+		$this->assertTrue($workflowdef->Actions()->first()->Transitions()->first()->canEdit());
+		$this->assertTrue($workflowdef->Actions()->first()->Transitions()->first()->canDelete());	
+	}	
+
+}

--- a/tests/workflowpermissions.yml
+++ b/tests/workflowpermissions.yml
@@ -1,0 +1,23 @@
+#
+# Models the various permission checks on Workflow objects
+#   
+WorkflowTransition:
+  test-transition-01:
+    Title: 'Test transition 01'
+      
+WorkflowAction:
+  action-no-transitions:
+    Title: 'No transitions'
+  action-with-transitions:
+    Title: 'With transitions'
+    Transitions: =>WorkflowTransition.test-transition-01
+  
+WorkflowDefinition:
+  no-actions:
+    Title: 'Test definition 01'
+  with-actions:
+    Title: 'Test definition 02'  
+    Actions: =>WorkflowAction.action-no-transitions
+  with-actions-and-transitions:
+    Title: 'Test definition 03'  
+    Actions: =>WorkflowAction.action-with-transitions


### PR DESCRIPTION
- Added canCreate/canEdit/canDelete() to Definition, Action & Transition.
- canEdit+canDelete call WorkflowDefinition#canCreate().
- Made WorkflowField UI buttons disabled based on the canXX() methods.
- Removed disableButton() methods, using canXX() in template directly.
- Added missing docblocks & tests.
