### PR TITLE
#148 Escaped DB refs to support PostgreSQL module.

### DIFF
--- a/code/dataobjects/WorkflowInstance.php
+++ b/code/dataobjects/WorkflowInstance.php
@@ -566,9 +566,9 @@ class WorkflowInstance extends DataObject {
 	 */
 	public function getVersionedConnection($recordID,$userID,$definitionID,$wasPublished=0) {
 		// Turn this into an array and run through implode()
-		$filter = "\"AuthorID\" = '".$userID."' AND \"RecordID\" = '".$recordID."' AND \"WorkflowDefinitionID\" = '".$definitionID."' AND WasPublished = '".$wasPublished."'";
+		$filter = "\"AuthorID\" = '".$userID."' AND \"RecordID\" = '".$recordID."' AND \"WorkflowDefinitionID\" = '".$definitionID."' AND \"WasPublished\" = '".$wasPublished."'";
 		$query = new SQLQuery();
-		$query->setFrom('SiteTree_versions')->setSelect('COUNT(ID)')->setWhere($filter);
+		$query->setFrom('"SiteTree_versions"')->setSelect('COUNT("ID")')->setWhere($filter);
 		$query->firstRow();
 		$hasAuthored = $query->execute();
 		if($hasAuthored) {


### PR DESCRIPTION
Escaped reference to SiteTree_versions table, ID and WasPublished fields in getVersionedConnection() method.  Fixes the issue #148 causing a Query Failed error in PostgreSQL due to trying to access tables and fields in lower case instead of mixed case.
