### PR TITLE
BUG Ability to add comments to first step in workflow

### DIFF
--- a/code/dataobjects/WorkflowAction.php
+++ b/code/dataobjects/WorkflowAction.php
@@ -3,6 +3,10 @@
  * A workflow action describes a the 'state' a workflow can be in, and
  * the action(s) that occur while in that state. An action can then have
  * subsequent transitions out of the current state. 
+ * 
+ * @method WorkflowDefinition WorkflowDef()
+ * @method Member Member()
+ * @method DataList Transitions()
  *
  * @author  marcus@silverstripe.com.au
  * @license BSD License (http://silverstripe.org/bsd-license/)
@@ -242,11 +246,51 @@ class WorkflowAction extends DataObject {
 	}
 	
 	/**
-	 * Used for Front End Workflows
+	 * 
+	 * Updates fields for when this is part of an active workflow
+	 * 
+	 * @param FieldList $fields
 	 */
-	public function updateFrontendWorkflowFields($fields, $workflow){	
+	public function updateWorkflowFields($fields) {
+		if ($this->AllowCommenting) {
+			$fields->push(new TextareaField(
+				'Comment',
+				_t('WorkflowAction.COMMENT', 'Comment')
+			));
+		}
+	}
+	
+	/**
+	 * Used for Front End Workflows
+	 * 
+	 * @param FieldList $fields
+	 * @param WorkFlowInstance $workflow {@see WorkflowInstance} context
+	 */
+	public function updateFrontendWorkflowFields($fields, $workflow = null){
+		if ($this->AllowCommenting) {		
+			$fields->push(new TextareaField(
+				'WorkflowActionInstanceComment',
+				_t('WorkflowAction.FRONTENDCOMMENT', 'Comment')
+			));
+		}
+	}
+	
+	/**
+	 * Get valid transitions for this action, given a workflow context
+	 * 
+	 * @param WorkFlowInstance $workflow {@see WorkflowInstance} context
+	 * @return SS_List
+	 */
+	public function getValidTransitions($workflow = null) {
 		
-	}	
+		// iterate through the transitions and see if they're valid for the current state of the item being
+		// workflowed
+		return $this
+			->Transitions()
+			->filterByCallback(function($transition) use($workflow) {
+				return $transition->isValid($workflow);
+			});
+	}
 	
 
 	public function Icon() {

--- a/code/dataobjects/WorkflowDefinition.php
+++ b/code/dataobjects/WorkflowDefinition.php
@@ -68,6 +68,41 @@ class WorkflowDefinition extends DataObject {
 	public function getInitialAction() {
 		if($actions = $this->Actions()) return $actions->First();
 	}
+	
+	/**
+	 * Gets fields for the first step of this workflow
+	 *
+	 * @return FieldList
+	 */
+	public function getWorkflowFields() {
+		$action    = $this->getInitialAction();
+		$options = $action->getValidTransitions();
+		$wfOptions = $options->map('ID', 'Title', ' ');
+		$fields    = new FieldList();
+
+		$fields->push(new HeaderField('WorkflowHeader', $action->Title));
+		$fields->push(new DropdownField('TransitionID', _t('WorkflowInstance.NEXT_ACTION', 'Next Action'), $wfOptions));
+
+		// Let the Active Action update the fields that the user can interact with so that data can be
+		// stored for the workflow.
+		$action->updateWorkflowFields($fields);
+
+		return $fields;
+	}
+	
+	/**
+	 * Gets Front-End form fields for the first step of this workflow
+	 * 
+	 * @return FieldList
+	 */
+	public function getFrontEndWorkflowFields() {
+		$action = $this->getInitialAction();
+		
+		$fields = new FieldList();
+		$action->updateFrontEndWorkflowFields($fields);
+		
+		return $fields;
+	}
 
 	/**
 	 * Ensure a sort value is set and we get a useable initial workflow title.

--- a/code/dataobjects/WorkflowInstance.php
+++ b/code/dataobjects/WorkflowInstance.php
@@ -6,6 +6,9 @@
  * button (eg 'apply for approval'). This creates a standalone object
  * that maintains the state of the workflow process. 
  * 
+ * @method WorkflowDefinition Definition()
+ * @method WorkflowActionInstance CurrentAction()
+ * @method Member Initiator()
  *
  * @author  marcus@silverstripe.com.au
  * @license BSD License (http://silverstripe.org/bsd-license/)

--- a/code/extensions/WorkflowApplicable.php
+++ b/code/extensions/WorkflowApplicable.php
@@ -241,6 +241,9 @@ class WorkflowApplicable extends DataExtension {
 		if ($active) {
 			return $active->canEdit();
 		}
+		if($effective = $this->workflowService->getDefinitionFor($this->owner)) {
+			return $effective->canEdit();
+		}
 		return false;
 	}
 }

--- a/code/services/WorkflowService.php
+++ b/code/services/WorkflowService.php
@@ -63,6 +63,7 @@ class WorkflowService implements PermissionProvider {
 	 * Will recursively query parent elements until it finds one, if available
 	 *
 	 * @param DataObject $dataObject
+	 * @return WorkflowDefinition The workflow definition, if present
 	 */
 	public function getDefinitionFor(DataObject $dataObject) {
 		if ($dataObject->hasExtension('WorkflowApplicable') || $dataObject->hasExtension('FileWorkflowApplicable')) {
@@ -161,9 +162,10 @@ class WorkflowService implements PermissionProvider {
 
 	/**
 	 * Starts the workflow for the given data object, assuming it or a parent has
-	 * a definition specified. 
+	 * a definition specified.
 	 * 
 	 * @param DataObject $object
+	 * @return WorkflowInstance The initiated instance, if available
 	 */
 	public function startWorkflow(DataObject $object) {
 		$existing = $this->getWorkflowFor($object);
@@ -176,7 +178,7 @@ class WorkflowService implements PermissionProvider {
 		if ($definition) {
 			$instance = new WorkflowInstance();
 			$instance->beginWorkflow($definition, $object);
-			$instance->execute();
+			return $instance;
 		}
 	}
 	


### PR DESCRIPTION
Fixes additional bug of finished steps not having Finished = true assigned

The basis of this PR came because notes and other action fields were not available on the first action, at which time there is no `WorkflowInstance` for the current object.

This fix refactors the responsibility for generating and presenting fields from the `WorkflowActionInstance` to the `WorkflowAction`. Individual subclasses of `WorkflowActionInstance` and `WorkflowAction` should still be  able to override these as necessary. This is necessary because sometimes we need these fields prior to the start of a new workflow.

The behaviour of AdvancedWorkflowExtension when creating and advancing workflows has been consolidated into a single `processWorkflow` method that will work equally well on new or updated records.

Because the behaviour of this update affects CMS usability, I think it's pretty critical that we get some behat tests going. Once @LukePercy has made some progress at https://github.com/silverstripe-australia/advancedworkflow/pull/136. Once this is integrated I will come back to this PR and add the appropriate tests. :)

Does someone mind to please manually check and test this to make sure nothing obvious has been broken?
