### PR TITLE
API Ability to reschedule existing embargo / unpublished dates

### DIFF
--- a/code/extensions/WorkflowEmbargoExpiryExtension.php
+++ b/code/extensions/WorkflowEmbargoExpiryExtension.php
@@ -74,12 +74,8 @@ class WorkflowEmbargoExpiryExtension extends DataExtension {
 				$dt = new Datetimefield('DesiredPublishDate', _t('WorkflowEmbargoExpiryExtension.REQUESTED_PUBLISH_DATE', 'Requested publish date')),
 				$ut = new Datetimefield('DesiredUnPublishDate', _t('WorkflowEmbargoExpiryExtension.REQUESTED_UNPUBLISH_DATE', 'Requested un-publish date')),
 				Datetimefield::create('PublishOnDate', _t('WorkflowEmbargoExpiryExtension.PUBLISH_ON', 'Scheduled publish date'))->setDisabled(true),
-				Datetimefield::create('UnPublishOnDate', _t('WorkflowEmbargoExpiryExtension.UNPUBLISH_ON', 'Scheduled un-publish date'))->setDisabled(true),
-				// Readonly fields do not store any value, so add a hidden-field and set its value to the current PublishOnDate so we can perform some validation
-				$uth = new HiddenField('PublishOnDateOwner')
+				Datetimefield::create('UnPublishOnDate', _t('WorkflowEmbargoExpiryExtension.UNPUBLISH_ON', 'Scheduled un-publish date'))->setDisabled(true)
 			));
-			// Set a value to our hidden field
-			$uth->setValue($this->owner->PublishOnDate);
 		} else {
 			$fields->addFieldsToTab('Root.PublishingSchedule', array(
 				new HeaderField('PublishDateHeader', _t('WorkflowEmbargoExpiryExtension.REQUESTED_PUBLISH_DATE_H3', 'Expiry and Embargo'), 3),
@@ -214,25 +210,12 @@ class WorkflowEmbargoExpiryExtension extends DataExtension {
 	 * @return array
 	 */
 	public function extendedRequiredFieldsCheckEmbargoDates($data = null) {
-		if(!$this->getIsWorkflowInEffect() || !isset($data['PublishOnDateOwner'])) {
+		if(!$this->getIsWorkflowInEffect()) {
 			return self::$extendedMethodReturn;
 		}
 		$desiredEmbargo = strtotime($data['DesiredPublishDate']);
-		$scheduledEmbargo = strtotime($data['PublishOnDateOwner']);
 		$desiredExpiry = strtotime($data['DesiredUnPublishDate']);
 		$msg = '';
-		if(strlen($data['DesiredPublishDate']) && $scheduledEmbargo > time()) {
-			$scheduledEmbargo = $this->getUserDate($data['PublishOnDateOwner']);
-			$msg = _t(
-				'WorkflowEmbargoExpiryExtension.EMBARGO_ERROR_PT1',
-				"This content is already under embargo, expiring at: ")
-				.$scheduledEmbargo.
-				_t(
-					'WorkflowEmbargoExpiryExtension.EMBARGO_ERROR_PT2',
-					' please wait until this date has passed, before applying a new embargo date.'
-			);
-			self::$extendedMethodReturn['fieldName'] = 'DesiredPublishDate';
-		}
 		if(strlen($data['DesiredPublishDate']) && $desiredEmbargo < time()) {
 			$msg = _t(
 				'EMBARGO_DSIRD_ERROR',


### PR DESCRIPTION
Responding to a user complaint, it seems obvious to me that a scheduled future publish date should be able to be changed. I'm unsure as to why it was necessary for this to cause a validation error in the first place. Having to wait until the embargo has been reached before changing it seems unreasonable.

Unit tests have been added, and I have run through a manual test to confirm that there were no obvious usability issues.

@phptek you wrote the original validation code at https://github.com/silverstripe-australia/advancedworkflow/pull/68. Are you able to provide a bit more justification as to why it was necessary?
