### PR TITLE
Fixes 3.1 deprecation warnings on static properties

### DIFF
--- a/code/actions/AssignUsersToWorkflowAction.php
+++ b/code/actions/AssignUsersToWorkflowAction.php
@@ -9,11 +9,11 @@
  */
 class AssignUsersToWorkflowAction extends WorkflowAction {
 
-	public static $db = array(
+	private static $db = array(
 		'AssignInitiator'		=> 'Boolean',
 	);
 
-	public static $many_many = array(
+	private static $many_many = array(
 		'Users'  => 'Member',
 		'Groups' => 'Group'
 	);

--- a/code/actions/NotifyUsersWorkflowAction.php
+++ b/code/actions/NotifyUsersWorkflowAction.php
@@ -8,7 +8,7 @@
  */
 class NotifyUsersWorkflowAction extends WorkflowAction {
 
-	public static $db = array(
+	private static $db = array(
 		'EmailSubject'			=> 'Varchar(100)',
 		'EmailFrom'				=> 'Varchar(50)',
 		'EmailTemplate'			=> 'Text',

--- a/code/actions/PublishItemWorkflowAction.php
+++ b/code/actions/PublishItemWorkflowAction.php
@@ -9,7 +9,7 @@
  */
 class PublishItemWorkflowAction extends WorkflowAction {
 
-	public static $db = array(
+	private static $db = array(
 		'PublishDelay' => 'Int'
 	);
 

--- a/code/dataobjects/ImportedWorkflowTemplate.php
+++ b/code/dataobjects/ImportedWorkflowTemplate.php
@@ -13,7 +13,7 @@ class ImportedWorkflowTemplate extends DataObject {
 	 *
 	 * @var array
 	 */
-	public static $db = array(
+	private static $db = array(
 		"Name" => "Varchar(255)",
 		"Filename" => "Varchar(255)",
 		"Content" => "Text"
@@ -23,7 +23,7 @@ class ImportedWorkflowTemplate extends DataObject {
 	 *
 	 * @var array
 	 */	
-	public static $has_one = array(
+	private static $has_one = array(
 		'Definition' => 'WorkflowDefinition'
 	);
 	

--- a/code/dataobjects/WorkflowAction.php
+++ b/code/dataobjects/WorkflowAction.php
@@ -10,7 +10,7 @@
  */
 class WorkflowAction extends DataObject {
 
-	public static $db = array(
+	private static $db = array(
 		'Title'				=> 'Varchar(255)',
 		'Comment'			=> 'Text',
 		'Type'				=> "Enum('Dynamic,Manual','Manual')",  // is this used?
@@ -20,18 +20,18 @@ class WorkflowAction extends DataObject {
 		'AllowCommenting'	=> 'Boolean'
 	);
 
-	public static $defaults = array(
+	private static $defaults = array(
 		'AllowCommenting'	=> '1',
 	);
-	
-	public static $default_sort = 'Sort';
 
-	public static $has_one = array(
+	private static $default_sort = 'Sort';
+
+	private static $has_one = array(
 		'WorkflowDef' => 'WorkflowDefinition',
 		'Member'      => 'Member'
 	);
 
-	public static $has_many = array(
+	private static $has_many = array(
 		'Transitions' => 'WorkflowTransition.Action'
 	);
 
@@ -41,8 +41,8 @@ class WorkflowAction extends DataObject {
 	 *
 	 * @var string
 	 */
-	public static $instance_class = 'WorkflowActionInstance';
-	
+	private static $instance_class = 'WorkflowActionInstance';
+
 	public static $icon = 'advancedworkflow/images/action.png';
 
 	/**

--- a/code/dataobjects/WorkflowActionInstance.php
+++ b/code/dataobjects/WorkflowActionInstance.php
@@ -12,18 +12,18 @@
  */
 class WorkflowActionInstance extends DataObject {
 
-	public static $db = array(
+	private static $db = array(
 		'Comment'  => 'Text',
 		'Finished' => 'Boolean'
 	);
 
-	public static $has_one = array(
+	private static $has_one = array(
 		'Workflow'   => 'WorkflowInstance',
 		'BaseAction' => 'WorkflowAction',
 		'Member'     => 'Member'
 	);
 	
-	public static $summary_fields = array(
+	private static $summary_fields = array(
 		'BaseAction.Title',
 		'Comment',
 		'Created',

--- a/code/dataobjects/WorkflowDefinition.php
+++ b/code/dataobjects/WorkflowDefinition.php
@@ -16,7 +16,8 @@
  * @package advancedworkflow
  */
 class WorkflowDefinition extends DataObject {
-	public static $db = array(
+
+	private static $db = array(
 		'Title'				=> 'Varchar(128)',
 		'Description'		=> 'Text',
 		'Template'			=> 'Varchar',
@@ -25,9 +26,9 @@ class WorkflowDefinition extends DataObject {
 		'Sort'				=> 'Int'
 	);
 
-	public static $default_sort = 'Sort';
+	private static $default_sort = 'Sort';
 
-	public static $has_many = array(
+	private static $has_many = array(
 		'Actions'   => 'WorkflowAction',
 		'Instances' => 'WorkflowInstance'
 	);
@@ -40,7 +41,7 @@ class WorkflowDefinition extends DataObject {
 	 *
 	 * @var array
 	 */
-	public static $many_many = array(
+	private static $many_many = array(
 		'Users' => 'Member',
 		'Groups' => 'Group'
 	);
@@ -51,7 +52,7 @@ class WorkflowDefinition extends DataObject {
 
 	public static $workflow_defs = array();
 
-	public static $dependencies = array(
+	private static $dependencies = array(
 		'workflowService'		=> '%$WorkflowService',
 	);
 	

--- a/code/dataobjects/WorkflowInstance.php
+++ b/code/dataobjects/WorkflowInstance.php
@@ -12,20 +12,21 @@
  * @package advancedworkflow
  */
 class WorkflowInstance extends DataObject {
-    public static $db = array(
+
+	private static $db = array(
 		'Title'				=> 'Varchar(128)',
 		'WorkflowStatus'	=> "Enum('Active,Paused,Complete,Cancelled','Active')",
 		'TargetClass'		=> 'Varchar(64)',
 		'TargetID'			=> 'Int',
 	);
 
-	public static $has_one = array(
+	private static $has_one = array(
 		'Definition'    => 'WorkflowDefinition',
 		'CurrentAction' => 'WorkflowActionInstance',
 		'Initiator'		=> 'Member',
 	);
 
-	public static $has_many = array(
+	private static $has_many = array(
 		'Actions'		=> 'WorkflowActionInstance',
 	);
 
@@ -34,12 +35,12 @@ class WorkflowInstance extends DataObject {
 	 *
 	 * @var array
 	 */
-	public static $many_many = array(
+	private static $many_many = array(
 		'Users'			=> 'Member',
 		'Groups'		=> 'Group'
 	);
 
-	public static $summary_fields = array(
+	private static $summary_fields = array(
 		'Title',
 		'WorkflowStatus',
 		'Created'

--- a/code/dataobjects/WorkflowTransition.php
+++ b/code/dataobjects/WorkflowTransition.php
@@ -15,20 +15,20 @@
  */
 class WorkflowTransition extends DataObject {
 
-	public static $db = array(
+	private static $db = array(
 		'Title' 	=> 'Varchar(128)',
 		'Sort'  	=> 'Int',
 		'Type' 		=> "Enum('Active, Passive', 'Active')"
 	);
 
-	public static $default_sort = 'Sort';
+	private static $default_sort = 'Sort';
 
-	public static $has_one = array(
+	private static $has_one = array(
 		'Action' => 'WorkflowAction',
 		'NextAction' => 'WorkflowAction',
 	);
 
-	public static $many_many = array(
+	private static $many_many = array(
 		'Users'  => 'Member',
 		'Groups' => 'Group'
 	);

--- a/code/extensions/WorkflowApplicable.php
+++ b/code/extensions/WorkflowApplicable.php
@@ -10,11 +10,11 @@
  */
 class WorkflowApplicable extends DataExtension {
 
-	public static $has_one = array(
+	private static $has_one = array(
 		'WorkflowDefinition' => 'WorkflowDefinition',
 	);
-	
-	public static $dependencies = array(
+
+	private static $dependencies = array(
 		'workflowService'		=> '%$WorkflowService',
 	);
 

--- a/code/extensions/WorkflowEmbargoExpiryExtension.php
+++ b/code/extensions/WorkflowEmbargoExpiryExtension.php
@@ -8,19 +8,19 @@
  */
 class WorkflowEmbargoExpiryExtension extends DataExtension {
 	
-	public static $db = array(
+	private static $db = array(
 		'DesiredPublishDate'	=> 'SS_Datetime',
 		'DesiredUnPublishDate'	=> 'SS_Datetime',
 		'PublishOnDate'			=> 'SS_Datetime',
 		'UnPublishOnDate'		=> 'SS_Datetime',
 	);
-	
-	public static $has_one = array(
+
+	private static $has_one = array(
 		'PublishJob'			=> 'QueuedJobDescriptor',
 		'UnPublishJob'			=> 'QueuedJobDescriptor',
 	);
 
-	public static $dependencies = array(
+	private static $dependencies = array(
 		'workflowService'		=> '%$WorkflowService',
 	);
 


### PR DESCRIPTION
This the standard change from 

```
  public static $db = array();
```

to
     private static $db = array();
