### PR TITLE
FIX: Fixes #164

### DIFF
--- a/code/dataobjects/WorkflowInstance.php
+++ b/code/dataobjects/WorkflowInstance.php
@@ -163,20 +163,18 @@ class WorkflowInstance extends DataObject {
 	 * Workflows are not restricted to being active on SiteTree objects,
 	 * so we need to account for being attached to anything.
 	 *
-	 * Uses Versioned instead of a straight call to DataObject::get_by_id(), if TargetClass
-	 * is versionable. This allows us to fetch Draft _and_ Published items.
+	 * Sets Versioned::set_reading_mode() to allow fetching of Draft _and_ Published
+	 * content.
 	 *
 	 * @return (null | DataObject)
 	 */
 	public function getTarget() {
 		if($this->TargetID && $this->TargetClass) {
-			$versionable = singleton($this->TargetClass)->has_extension('Versioned');
+			$versionable = Injector::inst()->get($this->TargetClass)->has_extension('Versioned');
 			if($versionable) {
-				return Versioned::get_all_versions($this->TargetClass, $this->TargetID)
-						->sort('ID', 'DESC')
-						->first();
+				Versioned::set_reading_mode("Stage.Stage");
 			}
-			
+
 			// Default
 			return DataObject::get_by_id($this->TargetClass, $this->TargetID);
 		}

--- a/code/extensions/WorkflowApplicable.php
+++ b/code/extensions/WorkflowApplicable.php
@@ -10,6 +10,39 @@
  */
 class WorkflowApplicable extends DataExtension {
 
+	/**
+	 *
+	 * Used to flag to this extension if there's a WorkflowPublishTargetJob running.
+	 * @var boolean
+	 */
+	public $isPublishJobRunning = false;
+
+	/**
+	 * 
+	 * @param boolean $truth
+	 */
+	public function setIsPublishJobRunning($truth) {
+		$this->isPublishJobRunning = $truth;
+	}
+
+	/**
+	 *
+	 * @return boolean
+	 */
+	public function getIsPublishJobRunning() {
+		return $this->isPublishJobRunning;
+	}
+
+	/**
+	 *
+	 * @see {@link $this->isPublishJobRunning}
+	 * @return boolean
+	 */
+	public function isPublishJobRunning() {
+		$propIsSet = $this->getIsPublishJobRunning() ? true : false;
+		return class_exists('AbstractQueuedJob') && $propIsSet;
+	}
+
 	public static $has_one = array(
 		'WorkflowDefinition' => 'WorkflowDefinition',
 	);
@@ -212,6 +245,11 @@ class WorkflowApplicable extends DataExtension {
 	 * If there's an active instance, then it 'might' be publishable
 	 */
 	public function canPublish() {
+		// Override any default behaviour, to allow queuedjobs to complete
+		if($this->isPublishJobRunning()) {
+			return true;
+		}
+
 		if ($active = $this->getWorkflowInstance()) {
 			return $active->canPublishTarget($this->owner);
 		}
@@ -221,13 +259,17 @@ class WorkflowApplicable extends DataExtension {
 		if ($effective = $this->workflowService->getDefinitionFor($this->owner)) {
 			return false;
 		}
-
 	}
 
 	/**
 	 * Can only edit content that's NOT in another person's content changeset
 	 */
 	public function canEdit($member) {
+		// Override any default behaviour, to allow queuedjobs to complete
+		if($this->isPublishJobRunning()) {
+			return true;
+		}
+
 		if ($active = $this->getWorkflowInstance()) {
 			return $active->canEditTarget($this->owner);
 		}

--- a/code/jobs/WorkflowPublishTargetJob.php
+++ b/code/jobs/WorkflowPublishTargetJob.php
@@ -21,10 +21,12 @@ class WorkflowPublishTargetJob extends AbstractQueuedJob {
 	public function process() {
 		if ($target = $this->getObject()) {
 			if ($this->publishType == 'publish') {
+				$target->setIsPublishJobRunning(true);
 				$target->PublishOnDate = '';
 				$target->writeWithoutVersion();
 				$target->doPublish();
 			} else if ($this->publishType == 'unpublish') {
+				$target->setIsPublishJobRunning(true);
 				$target->UnPublishOnDate = '';
 				$target->writeWithoutVersion();
 				$target->doUnpublish();

--- a/css/AdvancedWorkflowAdmin.css
+++ b/css/AdvancedWorkflowAdmin.css
@@ -1,3 +1,3 @@
-.icon.icon-16.icon-advancedworkflowadmin {
-	background-image: url(../images/workflow-menu-icon.png);
-}
+.icon.icon-16.icon-advancedworkflowadmin { background-image: url(../images/workflow-menu-icon.png); }
+
+.field.date .message.required, .field.datetime .message.required { position: relative; top: 10px; }

--- a/scss/AdvancedWorkflowAdmin.scss
+++ b/scss/AdvancedWorkflowAdmin.scss
@@ -1,0 +1,11 @@
+.icon.icon-16.icon-advancedworkflowadmin {
+	background-image: url(../images/workflow-menu-icon.png);
+}
+.field.date, .field.datetime {
+	.message {
+		&.required {
+			position: relative;
+			top: 10px;
+		}
+	}
+}


### PR DESCRIPTION
- Adds logic to allow `WorkflowPublishTargetJob` to signal targets that
  jobs are running
- Fixes inability of users to change a scheduled embargo date.
- Fixed CSS for date validation error.
