### PR TITLE
BUG Saving page from another tab than content causes !isset error

### DIFF
--- a/code/extensions/WorkflowEmbargoExpiryExtension.php
+++ b/code/extensions/WorkflowEmbargoExpiryExtension.php
@@ -224,8 +224,17 @@ class WorkflowEmbargoExpiryExtension extends DataExtension {
 			return self::$extendedMethodReturn;
 		}
 
-		$desiredEmbargo = strtotime($data['DesiredPublishDate']);
-		$desiredExpiry = strtotime($data['DesiredUnPublishDate']);
+		$desiredEmbargo = false;
+		$desiredExpiry = false;
+
+		if(!empty($data['DesiredPublishDate'])) {
+			$desiredEmbargo = strtotime($data['DesiredPublishDate']);
+		}
+
+		if(!empty($data['DesiredPublishDate'])) {
+			$desiredExpiry = strtotime($data['DesiredUnPublishDate']);
+		}
+
 		$msg = '';
 
 		if($desiredEmbargo && $desiredEmbargo < time()) {


### PR DESCRIPTION
When a workflow is in effect and WorkflowEmbargoExpiryExtension is active the
code wrongly assumes that the DesiredPublishDate and DesiredPublishDate is
always set.
