### PR TITLE
SECURITY: Enforce the DELETE_WORKFLOW permission for active workflows.

### DIFF
--- a/code/dataobjects/WorkflowInstance.php
+++ b/code/dataobjects/WorkflowInstance.php
@@ -403,8 +403,7 @@ class WorkflowInstance extends DataObject {
 		if(Permission::checkMember($member, "DELETE_WORKFLOW")) {
 			return true;
 		}
-
-		return $this->userHasAccess($member);
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
A user now must have the DELETE_WORKFLOW permission do be able to delete an active workflow. This will prevent unprivileged users from stopping the current workflow.
