### PR TITLE
FIX: Include i18n JS in WorkflowEmbargoExpiryExtension

### DIFF
--- a/code/extensions/WorkflowEmbargoExpiryExtension.php
+++ b/code/extensions/WorkflowEmbargoExpiryExtension.php
@@ -55,6 +55,8 @@ class WorkflowEmbargoExpiryExtension extends DataExtension {
 	 * @param FieldList $fields
 	 */
 	public function updateCMSFields(FieldList $fields) {
+		Requirements::add_i18n_javascript(ADVANCED_WORKFLOW_DIR . '/javascript/lang');
+
 		// Add timepicker functionality
 		// @see https://github.com/trentrichardson/jQuery-Timepicker-Addon
 		Requirements::css(


### PR DESCRIPTION
Previously, the i18n JS was only included when going to the Workflows section of the CMS, which was fine when it was built. The translations are now also used by the EmbargoExpiry extension, so if went straight to the 'Pages' section of the CMS, the translations weren't being included by the CMS.

I didn't include fallback strings into each of the _t() calls, but I can do if you'd prefer? I wasn't sure if we should still be providing these or not - in this case it would have always used the fallback string, which wouldn't be much use in other languages.
