### PR TITLE
BUG Fixing validation of past dates not being allowed.

### DIFF
--- a/code/extensions/WorkflowEmbargoExpiryExtension.php
+++ b/code/extensions/WorkflowEmbargoExpiryExtension.php
@@ -313,56 +313,6 @@ class WorkflowEmbargoExpiryExtension extends DataExtension {
 		return $required;
 	}
 
-	/**
-	 *
-	 * Uses AWRequiredFields to peform validation at the DataExtension level.
-	 *
-	 * @see {@ink AWRequiredFields}
-	 * @param array $data
-	 * @return array
-	 */
-	public function extendedRequiredFieldsCheckEmbargoDates($data = null) {
-		if(!$this->getIsWorkflowInEffect()) {
-			return self::$extendedMethodReturn;
-		}
-
-		$desiredEmbargo = false;
-		$desiredExpiry = false;
-
-		if(!empty($data['DesiredPublishDate'])) {
-			$desiredEmbargo = strtotime($data['DesiredPublishDate']);
-		}
-
-		if(!empty($data['DesiredPublishDate'])) {
-			$desiredExpiry = strtotime($data['DesiredUnPublishDate']);
-		}
-
-		$msg = '';
-
-		if($desiredEmbargo && $desiredEmbargo < time()) {
-			$msg = _t(
-				'EMBARGO_DSIRD_ERROR',
-				"This date has already passed, please enter a valid future date."
-			);
-			self::$extendedMethodReturn['fieldName'] = 'DesiredPublishDate';
-		}
-
-		if($desiredExpiry && $desiredExpiry < time()) {
-			$msg = _t(
-				'EMBARGO_DSIRD_ERROR',
-				"This date has already passed, please enter a valid future date."
-			);
-			self::$extendedMethodReturn['fieldName'] = 'DesiredUnPublishDate';
-		}
-
-		if(strlen($msg)) {
-			self::$extendedMethodReturn['fieldValid'] = false;
-			self::$extendedMethodReturn['fieldMsg'] = $msg;
-		}
-
-		return self::$extendedMethodReturn;
-	}
-
 	/*
 	 * Format a date according to member/user preferences
 	 *


### PR DESCRIPTION
If setting a past publish date, the job should just be triggered to
publish right now.
This is how WorkflowEmbargoExpiryExtension::onBeforeWrite() will work,
so it doesn't make sense to validate this.

Note this also fixes the issue where someone sets a publish date of
today, and hits "Now" for time, but validation fails because the
desired time has already passed by the time the person hits save.

Ref: PLAT-128, CWPBUG-164
