### PR TITLE
Implementing support for multiple workflow definitions.

### DIFF
--- a/code/dataobjects/WorkflowDefinition.php
+++ b/code/dataobjects/WorkflowDefinition.php
@@ -23,7 +23,8 @@ class WorkflowDefinition extends DataObject {
 		'Template'			=> 'Varchar',
 		'TemplateVersion'	=> 'Varchar',
 		'RemindDays'		=> 'Int',
-		'Sort'				=> 'Int'
+		'Sort'				=> 'Int',
+		'InitialActionButtonText' => 'Varchar'
 	);
 
 	private static $default_sort = 'Sort';
@@ -173,6 +174,10 @@ class WorkflowDefinition extends DataObject {
 
 		$fields->addFieldToTab('Root.Main', new TextField('Title', $this->fieldLabel('Title')));
 		$fields->addFieldToTab('Root.Main', new TextareaField('Description', $this->fieldLabel('Description')));
+		$fields->addFieldToTab('Root.Main', TextField::create(
+			'InitialActionButtonText',
+			_t('WorkflowDefinition.INITIAL_ACTION_BUTTON_TEXT', 'Initial Action Button Text')
+		));
 		if($this->ID) {
 			$fields->addFieldToTab('Root.Main', new CheckboxSetField('Users', _t('WorkflowDefinition.USERS', 'Users'), $cmsUsers));
 			$fields->addFieldToTab('Root.Main', new TreeMultiselectField('Groups', _t('WorkflowDefinition.GROUPS', 'Groups'), 'Group'));

--- a/code/dataobjects/WorkflowInstance.php
+++ b/code/dataobjects/WorkflowInstance.php
@@ -438,7 +438,7 @@ class WorkflowInstance extends DataObject {
 		$inWorkflowGroupOrUserTables = ($member->inGroups($this->Groups()) || $this->Users()->find('ID', $member->ID));
 		// This method is used in more than just the ModelAdmin. Check for the current controller to determine where canView() expectations differ
 		if($this->getTarget() && Controller::curr()->getAction() == 'index' && !$inWorkflowGroupOrUserTables) {
-			if($this->getVersionedConnection($this->getTarget()->ID,$member->ID,$this->DefinitionID)) {
+			if($this->getVersionedConnection($this->getTarget()->ID, $member->ID)) {
 				return true;
 			}
 			return false;
@@ -598,13 +598,12 @@ class WorkflowInstance extends DataObject {
 	 *
 	 * @param number $recordID
 	 * @param number $userID
-	 * @param number $definitionID
 	 * @param number $wasPublished
 	 * @return boolean
 	 */
-	public function getVersionedConnection($recordID,$userID,$definitionID,$wasPublished=0) {
+	public function getVersionedConnection($recordID, $userID, $wasPublished = 0) {
 		// Turn this into an array and run through implode()
-		$filter = "\"AuthorID\" = '".$userID."' AND \"RecordID\" = '".$recordID."' AND \"WorkflowDefinitionID\" = '".$definitionID."' AND \"WasPublished\" = '".$wasPublished."'";
+		$filter = "RecordID = {$recordID} AND AuthorID = {$userID} AND WasPublished = {$wasPublished}";
 		$query = new SQLQuery();
 		$query->setFrom('"SiteTree_versions"')->setSelect('COUNT("ID")')->setWhere($filter);
 		$query->firstRow();

--- a/code/extensions/AdvancedWorkflowExtension.php
+++ b/code/extensions/AdvancedWorkflowExtension.php
@@ -9,8 +9,13 @@
  */
 class AdvancedWorkflowExtension extends LeftAndMainExtension {
 
+	private static $allowed_actions = array(
+		'startworkflow'
+	);
+
 	public function startworkflow($data, $form, $request) {
 		$item = $form->getRecord();
+		$workflowID = isset($data['TriggeredWorkflowID']) ? intval($data['TriggeredWorkflowID']) : 0;
 
 		if (!$item || !$item->canEdit()) {
 			return;
@@ -20,7 +25,7 @@ class AdvancedWorkflowExtension extends LeftAndMainExtension {
 		$this->saveAsDraftWithAction($form, $item);
 
 		$svc = singleton('WorkflowService');
-		$svc->startWorkflow($item);
+		$svc->startWorkflow($item, $workflowID);
 
 		return $this->owner->getResponseNegotiator()->respond($this->owner->getRequest());
 	}
@@ -32,6 +37,8 @@ class AdvancedWorkflowExtension extends LeftAndMainExtension {
 	 * @param Form $form
 	 */
 	public function updateEditForm(Form $form) {
+
+		Requirements::javascript(ADVANCED_WORKFLOW_DIR . '/javascript/advanced-workflow-cms.js');
 		$svc    = singleton('WorkflowService');
 		$p      = $form->getRecord();
 		$active = $svc->getWorkflowFor($p);

--- a/javascript/advanced-workflow-cms.js
+++ b/javascript/advanced-workflow-cms.js
@@ -1,0 +1,24 @@
+;(function($) {
+	$(function() {
+
+		$.entwine('ss', function($) {
+
+			$('.cms-edit-form .Actions .action.start-workflow').entwine({
+				onmouseup: function(e) {
+
+					// Populate the hidden form field with the selected workflow definition.
+
+					var action = $(this);
+					$('input[name=TriggeredWorkflowID]').val(action.data('workflow'));
+
+					// Update the element name to exclude the ID, therefore submitting correctly.
+
+					var name = action.attr('name');
+					action.attr('name', name.replace(/-\d+/, ''));
+					this._super(e);
+				}
+			});
+		});
+
+	});
+})(jQuery);


### PR DESCRIPTION
This is a similar concept to pull request https://github.com/silverstripe-australia/advancedworkflow/pull/99, however more focused on triggering only a single workflow instance at a time (from multiple that may have been assigned).

![0](https://cloud.githubusercontent.com/assets/3703500/4820997/54b191a6-5f22-11e4-8ee9-a2d0f63c8667.png)

This avoids the possible conflicts that were outlined in the previous thread, however allows extension when we choose to approach that problem.

![1](https://cloud.githubusercontent.com/assets/3703500/4820998/5aff7b0e-5f22-11e4-90f5-422850fc259a.png)

@nyeholt
