### PR TITLE
BUG Fix transition permission detection including tests

### DIFF
--- a/code/dataobjects/WorkflowInstance.php
+++ b/code/dataobjects/WorkflowInstance.php
@@ -5,7 +5,10 @@
  * This 'start' is triggered automatically when the user clicks the relevant 
  * button (eg 'apply for approval'). This creates a standalone object
  * that maintains the state of the workflow process. 
- * 
+ *
+ * @method WorkflowDefinition Definition()
+ * @method WorkflowActionInstance CurrentAction()
+ * @method Member Initiator()
  *
  * @author  marcus@silverstripe.com.au
  * @license BSD License (http://silverstripe.org/bsd-license/)
@@ -488,16 +491,12 @@ class WorkflowInstance extends DataObject {
 	public function validTransitions() {
 		$action    = $this->CurrentAction();
 		$transitions = $action->getValidTransitions();
-		$member = Member::currentUser();
-		$validTransitions = ArrayList::create();
 
-		foreach ($transitions as $key => $transition) {
-			if ($member->inGroups($transition->Groups()) || Permission::check('ADMIN')) {
-				$validTransitions->add($transition);
-			}
-		}
-
-		return $validTransitions;
+		// Filter by execute permission
+		$self = $this;
+		return $transitions->filterByCallback(function($transition) use ($self) {
+			return $transition->canExecute($self);
+		});
 	}
 	
 	/* UI RELATED METHODS */

--- a/tests/WorkflowInstanceTest.php
+++ b/tests/WorkflowInstanceTest.php
@@ -89,4 +89,30 @@ class WorkflowInstanceTest extends SapphireTest {
 		$this->assertTrue($history05->canView($this->currentMember));	
 	}
 
+	public function testValidTransitions() {
+		$instance = $this->objFromFixture('WorkflowInstance', 'WorkflowInstance06');
+		$transition1 = $this->objFromFixture('WorkflowTransition', 'Transition05');
+		$transition2 = $this->objFromFixture('WorkflowTransition', 'Transition06');
+		$member1 = $this->objFromFixture('Member', 'Transition05Member');
+		$member2 = $this->objFromFixture('Member', 'Transition06Member');
+
+		// Given logged in as admin, check that there are two actions
+		$this->logInWithPermission('ADMIN');
+		$transitions = $instance->validTransitions()->column('ID');
+		$this->assertContains($transition1->ID, $transitions);
+		$this->assertContains($transition2->ID, $transitions);
+
+		// Logged in as a member with permission on one transition, check that only this one is present
+		$member1->logIn();
+		$transitions = $instance->validTransitions()->column('ID');
+		$this->assertContains($transition1->ID, $transitions);
+		$this->assertNotContains($transition2->ID, $transitions);
+
+		// Logged in as a member with permissions via group
+		$member2->logIn();
+		$transitions = $instance->validTransitions()->column('ID');
+		$this->assertNotContains($transition1->ID, $transitions);
+		$this->assertContains($transition2->ID, $transitions);
+	}
+
 }

--- a/tests/useractioninstancehistory.yml
+++ b/tests/useractioninstancehistory.yml
@@ -1,6 +1,30 @@
 #
 # Models the first part of the default _config YML template as a fixture as though it's been run and is part way through
 #
+    
+Member:
+  ApproverMember01:
+    ID: 1
+    FirstName: General
+    Surname: Approver
+    Email: g.approver@localhost
+  Transition05Member:
+    FirstName: Five
+    Surname: Executer
+    Email: five.executor@localhost
+  Transition06Member:
+    FirstName: Six
+    Surname: Executer
+    Email: six.executor@localhost
+  
+Group:
+  BaseAction01Group:
+    Title: Approvers
+    Members: =>Member.ApproverMember01
+  Transition05Group:
+    Title: CanExecuteTransition05
+    Members: =>Member.Transition05Member
+    
 WorkflowTransition:
   Transition01:
     Title: notify
@@ -10,18 +34,12 @@ WorkflowTransition:
     Title: Approve
   Transition04:
     Title: Reject
-    
-Member:
-  ApproverMember01:
-    ID: 1
-    FirstName: General
-    Surname: Approver
-    Email: g.approver@localhost
-  
-Group:
-  BaseAction01Group:
-    Title: Approvers
-    Members: =>Member.ApproverMember01
+  Transition05:
+    Title: 'Transition with Groups'
+    Groups: =>Group.Transition05Group
+  Transition06:
+    Title: 'Transition with User'
+    Users: =>Member.Transition06Member
 
 AssignUsersToWorkflowAction:
   BaseAction01:
@@ -55,8 +73,11 @@ SimpleApprovalWorkflowAction:
     Transitions: =>WorkflowTransition.Transition03,=>WorkflowTransition.Transition04
   BaseAction031:
     Title: Approval
-    Transitions: =>WorkflowTransition.Transition03,=>WorkflowTransition.Transition04    
- 
+    Transitions: =>WorkflowTransition.Transition03,=>WorkflowTransition.Transition04 
+  BaseAction032:
+    Title: Approval
+    Transitions: =>WorkflowTransition.Transition05,=>WorkflowTransition.Transition06
+
 WorkflowActionInstance:
   ActionInstance01:
     Created: '2014-02-17 16:15:00'
@@ -117,7 +138,11 @@ WorkflowActionInstance:
   ActionInstance15:
     Created: '2014-02-17 16:15:03'      
     Finished: 1
-    BaseAction: =>AssignUsersToWorkflowAction.BaseAction014   
+    BaseAction: =>AssignUsersToWorkflowAction.BaseAction014
+  ActionInstance16:
+    Created: '2014-02-17 16:15:00'
+    Finished: 1
+    BaseAction: =>SimpleApprovalWorkflowAction.BaseAction032
   
 WorkflowInstance:
   WorkflowInstance01:
@@ -140,4 +165,8 @@ WorkflowInstance:
     Title: 'Test WorkflowInstance 05'
     WorkflowStatus: Paused
     Actions: =>WorkflowActionInstance.ActionInstance12,=>WorkflowActionInstance.ActionInstance13,=>WorkflowActionInstance.ActionInstance14,=>WorkflowActionInstance.ActionInstance15
- 
+  WorkflowInstance06:
+    Title: 'Test WorkflowInstance 06'
+    WorkflowStatus: Paused
+    Actions: =>WorkflowActionInstance.ActionInstance16
+    CurrentAction: =>WorkflowActionInstance.ActionInstance16


### PR DESCRIPTION
This builds on a prior bugfix, although this includes test cases, fixes for member permission assignment, and better respects the behaviour of `WorkflowTransition::canExecute`.
