### PR TITLE
Remove editor dialog on unmatch to prevent multiple dialogs

### DIFF
--- a/javascript/WorkflowField.js
+++ b/javascript/WorkflowField.js
@@ -12,7 +12,8 @@ jQuery.entwine("workflow", function($) {
 				autoOpen: false,
 				width:    800,
 				height:   600,
-				modal:    true
+				modal:    true,
+				dialogClass: 'workflow-field-editor-dialog'
 			});
 
 			this.getDialog().on("click", "button", function() {
@@ -31,6 +32,9 @@ jQuery.entwine("workflow", function($) {
 
 				return false;
 			});
+		},
+		onunmatch: function () {
+			$('.workflow-field-editor-dialog').remove();
 		},
 		showDialog: function(url) {
 			var dlg = this.getDialog();


### PR DESCRIPTION
To reproduce this issue:

1) Select an existing workflow definition from the Workflows gridfield.
2) Select the edit button (pencil) on a transition, which displays the dialog editor. See Action, Next action, Type dropdowns are present.
3) Select 'Workflows' from the left nav to get back to /admin/workflows.
4) Select the same workflow definition as before, and again click the edit button to display the dialog. See the Action, Next action, and Type dropdowns are now missing.

This is because each time a new WorkflowField is created, a new dialog is also created, and in turn, another editor form. The dropdown fields in these editor forms have the same id attribute, so Chosen tries to apply dropdown behaviour to the first field matching the id, which on subsequent visits to the workflow definition is the incorrect form.

The fix removes the dialog when leaving the view.
