### PR TITLE
fix(FrontEndWorkflowController): Fixed ->extend hooks to use proper fields as named.

### DIFF
--- a/code/controllers/FrontEndWorkflowController.php
+++ b/code/controllers/FrontEndWorkflowController.php
@@ -102,8 +102,8 @@ abstract class FrontEndWorkflowController extends Controller {
 		$active->setFrontendFormRequirements();
 				
 		// hooks for decorators
-		$this->extend('updateFrontEndWorkflowFields', $wfActions);
-		$this->extend('updateFrontEndWorkflowActions', $wfFields);
+		$this->extend('updateFrontEndWorkflowFields', $wfFields);
+		$this->extend('updateFrontEndWorkflowActions', $wfActions);
 		$this->extend('updateFrontEndRequiredFields', $wfValidator);
 		$this->extend('updateFrontendFormRequirements');
 	   


### PR DESCRIPTION
fix(FrontEndWorkflowController): Fixed ->extend hooks to use proper fields as named.

Look closely at $wfActions/$wfFields. They're being passed into the wrong ->extend.