### PR TITLE
fix(WorkflowInstance) Added condition for targetDiff for prior SS 4.7 & PHP 7.4 upgrade

### DIFF
--- a/src/DataObjects/WorkflowInstance.php
+++ b/src/DataObjects/WorkflowInstance.php
@@ -296,8 +296,11 @@ class WorkflowInstance extends DataObject
         $diff->ignoreFields($this->config()->get('diff_ignore_fields'));
 
         $fields = ArrayList::create();
+
         try {
-            $fields = $diff->ChangedFields();
+            if ($diff && !(is_null($diff->fromRecord) && is_null($diff->toRecord))) {
+                $fields = $diff->ChangedFields();
+            }
         } catch (\InvalidArgumentException $iae) {
             // noop
         }
@@ -320,7 +323,8 @@ class WorkflowInstance extends DataObject
             $this->write();
         }
 
-        if ($for
+        if (
+            $for
             && ($for->hasExtension(WorkflowApplicable::class)
                 || $for->hasExtension(FileWorkflowApplicable::class))
         ) {
@@ -789,7 +793,7 @@ class WorkflowInstance extends DataObject
         $action = WorkflowAction::get()
             /** @skipUpgrade */
             ->leftJoin('WorkflowActionInstance', $join)
-            ->where('"WorkflowActionInstance"."ID" = '.$this->CurrentActionID)
+            ->where('"WorkflowActionInstance"."ID" = ' . $this->CurrentActionID)
             ->first();
         if (!$action) {
             return 'N/A';
@@ -814,7 +818,7 @@ class WorkflowInstance extends DataObject
 
         // WorkflowActionInstances in reverse creation-order so we get the most recent one's first
         $history = $this->Actions()->filter(array(
-            'Finished' =>1,
+            'Finished' => 1,
             'BaseAction.ClassName' => AssignUsersToWorkflowAction::class
         ))->Sort('Created', 'DESC');
 


### PR DESCRIPTION
As part of bumping the SilverStripe version to 4.7 and PHP 7.4, this change request fixes the error;

` Call to a member function toMap() ` when the  DataDifferencer::fromRecord and DataDifferencer::toRecord variables are null.

Usually happens on the test and local environment.