### PR TITLE
FIX don't remove jobs when processing via publish job

### DIFF
--- a/src/Extensions/WorkflowEmbargoExpiryExtension.php
+++ b/src/Extensions/WorkflowEmbargoExpiryExtension.php
@@ -182,7 +182,7 @@ class WorkflowEmbargoExpiryExtension extends DataExtension
     public function clearPublishJob()
     {
         $job = $this->owner->PublishJob();
-        if ($job && $job->exists()) {
+        if ($job && $job->exists() && !$job->JobFinished) {
             $job->delete();
         }
         $this->owner->PublishJobID = 0;
@@ -195,7 +195,7 @@ class WorkflowEmbargoExpiryExtension extends DataExtension
     {
         // Cancel any in-progress unpublish job
         $job = $this->owner->UnPublishJob();
-        if ($job && $job->exists()) {
+        if ($job && $job->exists() && !$job->JobFinished) {
             $job->delete();
         }
         $this->owner->UnPublishJobID = 0;
@@ -297,6 +297,10 @@ class WorkflowEmbargoExpiryExtension extends DataExtension
 
         // Jobs can only be queued for records that already exist
         if (!$this->owner->ID) {
+            return;
+        }
+        
+        if ($this->owner->hasMethod('isPublishJobRunning') && $this->owner->isPublishJobRunning()) {
             return;
         }
 


### PR DESCRIPTION
WorkflowPublishTargetJob::process() triggers a onBeforeWrite() which in turn can lead to job descriptors being deleted while still being used.