### PR TITLE
Add extension hook to WorkflowInstance::getCMSFields()

### DIFF
--- a/src/DataObjects/WorkflowInstance.php
+++ b/src/DataObjects/WorkflowInstance.php
@@ -165,6 +165,8 @@ class WorkflowInstance extends DataObject
 
         $fields->addFieldsToTab('Root.Main', $grid);
 
+        $this->extend('updateCMSFields', $fields);
+
         return $fields;
     }
 


### PR DESCRIPTION
Class WorkflowInstance is missing extension hook in getCMSFields method.