### PR TITLE
NEW Extend new AbstractGridFieldComponent class

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "silverstripe/cms": "^4",
-        "silverstripe/framework": "^4.10",
+        "silverstripe/framework": "^4.11",
         "silverstripe/admin": "^1",
         "silverstripe/versioned": "^1",
         "symfony/yaml": "^3 || ^4"

--- a/src/Admin/AdvancedWorkflowAdmin.php
+++ b/src/Admin/AdvancedWorkflowAdmin.php
@@ -119,9 +119,9 @@ class AdvancedWorkflowAdmin extends ModelAdmin
         }
 
         // Pending/Submitted items GridField Config
-        $config = new GridFieldConfig_Base();
-        $config->addComponent(new GridFieldEditButton());
-        $config->addComponent(new GridFieldDetailForm());
+        $config = GridFieldConfig_Base::create();
+        $config->addComponent(GridFieldEditButton::create());
+        $config->addComponent(GridFieldDetailForm::create());
         $config->getComponentByType(GridFieldPaginator::class)->setItemsPerPage(5);
         $columns = $config->getComponentByType(GridFieldDataColumns::class);
         $columns->setFieldFormatting($this->setFieldFormatting($config));
@@ -173,7 +173,7 @@ class AdvancedWorkflowAdmin extends ModelAdmin
 
             $formFieldBottom->setForm($form);
             $formFieldBottom->getConfig()->removeComponentsByType(GridFieldEditButton::class);
-            $formFieldBottom->getConfig()->addComponent(new GridFieldWorkflowRestrictedEditButton());
+            $formFieldBottom->getConfig()->addComponent(GridFieldWorkflowRestrictedEditButton::create());
             $form->Fields()->insertBefore($definitionGridFieldName, $formFieldBottom);
         }
 
@@ -189,7 +189,7 @@ class AdvancedWorkflowAdmin extends ModelAdmin
 
             $grid->getConfig()->getComponentByType(GridFieldDetailForm::class)
                 ->setItemRequestClass(WorkflowDefinitionItemRequestClass::class);
-            $grid->getConfig()->addComponent(new GridFieldExportAction());
+            $grid->getConfig()->addComponent(GridFieldExportAction::create());
             $grid->getConfig()->removeComponentsByType(GridFieldExportButton::class);
             $grid->getConfig()->removeComponentsByType(GridFieldImportButton::class);
         }

--- a/src/DataObjects/WorkflowDefinition.php
+++ b/src/DataObjects/WorkflowDefinition.php
@@ -342,11 +342,11 @@ class WorkflowDefinition extends DataObject
                 'WorkflowStatus' => ['Active', 'Paused']
             ]);
 
-            $active = new GridField(
+            $active = GridField::create(
                 'Active',
                 _t('WorkflowDefinition.WORKFLOWACTIVEIINSTANCES', 'Active Workflow Instances'),
                 $active,
-                new GridFieldConfig_RecordEditor()
+                GridFieldConfig_RecordEditor::create()
             );
 
             $active->getConfig()->removeComponentsByType(GridFieldAddNewButton::class);
@@ -354,19 +354,19 @@ class WorkflowDefinition extends DataObject
 
             if (!Permission::check('REASSIGN_ACTIVE_WORKFLOWS')) {
                 $active->getConfig()->removeComponentsByType(GridFieldEditButton::class);
-                $active->getConfig()->addComponent(new GridFieldViewButton());
-                $active->getConfig()->addComponent(new GridFieldDetailForm());
+                $active->getConfig()->addComponent(GridFieldViewButton::create());
+                $active->getConfig()->addComponent(GridFieldDetailForm::create());
             }
 
             $completed = $this->Instances()->filter([
                 'WorkflowStatus' => ['Complete', 'Cancelled']
             ]);
 
-            $config = new GridFieldConfig_Base();
-            $config->addComponent(new GridFieldEditButton());
-            $config->addComponent(new GridFieldDetailForm());
+            $config = GridFieldConfig_Base::create();
+            $config->addComponent(GridFieldEditButton::create());
+            $config->addComponent(GridFieldDetailForm::create());
 
-            $completed = new GridField(
+            $completed = GridField::create(
                 'Completed',
                 _t('WorkflowDefinition.WORKFLOWCOMPLETEDIINSTANCES', 'Completed Workflow Instances'),
                 $completed,

--- a/src/DataObjects/WorkflowInstance.php
+++ b/src/DataObjects/WorkflowInstance.php
@@ -157,7 +157,7 @@ class WorkflowInstance extends DataObject
             'WorkflowID' => $this->ID
         ));
 
-        $grid = new GridField(
+        $grid = GridField::create(
             'Actions',
             _t('WorkflowInstance.ActionLogTitle', 'Log'),
             $items

--- a/src/Extensions/WorkflowApplicable.php
+++ b/src/Extensions/WorkflowApplicable.php
@@ -161,12 +161,12 @@ class WorkflowApplicable extends DataExtension
         }
 
         if ($this->owner->ID) {
-            $config = new GridFieldConfig_Base();
-            $config->addComponent(new GridFieldEditButton());
-            $config->addComponent(new GridFieldDetailForm());
+            $config = GridFieldConfig_Base::create();
+            $config->addComponent(GridFieldEditButton::create());
+            $config->addComponent(GridFieldDetailForm::create());
 
             $insts = $this->owner->WorkflowInstances();
-            $log = new GridField(
+            $log = GridField::create(
                 'WorkflowLog',
                 _t('WorkflowApplicable.WORKFLOWLOG', 'Workflow Log'),
                 $insts,

--- a/src/Forms/gridfield/GridFieldExportAction.php
+++ b/src/Forms/gridfield/GridFieldExportAction.php
@@ -5,6 +5,7 @@ namespace Symbiote\AdvancedWorkflow\Forms\GridField;
 use SilverStripe\Control\Controller;
 use SilverStripe\Control\Director;
 use SilverStripe\Core\Config\Config;
+use SilverStripe\Forms\GridField\AbstractGridFieldComponent;
 use SilverStripe\Forms\GridField\GridField;
 use SilverStripe\Forms\GridField\GridField_ActionProvider;
 use SilverStripe\Forms\GridField\GridField_ColumnProvider;
@@ -22,7 +23,9 @@ use Symbiote\AdvancedWorkflow\Admin\AdvancedWorkflowAdmin;
  * @license BSD License (http://silverstripe.org/bsd-license/)
  * @package advancedworkflow
  */
-class GridFieldExportAction implements GridField_ColumnProvider, GridField_ActionProvider
+class GridFieldExportAction extends AbstractGridFieldComponent implements
+    GridField_ColumnProvider,
+    GridField_ActionProvider
 {
     /**
      * Add a column 'Delete'

--- a/src/Forms/gridfield/GridFieldWorkflowRestrictedEditButton.php
+++ b/src/Forms/gridfield/GridFieldWorkflowRestrictedEditButton.php
@@ -3,6 +3,7 @@
 namespace Symbiote\AdvancedWorkflow\Forms\GridField;
 
 use SilverStripe\Control\Controller;
+use SilverStripe\Forms\GridField\AbstractGridFieldComponent;
 use SilverStripe\Forms\GridField\GridField_ColumnProvider;
 use SilverStripe\Forms\GridField\GridFieldEditButton;
 use SilverStripe\Security\Permission;
@@ -14,7 +15,7 @@ use Symbiote\AdvancedWorkflow\DataObjects\WorkflowInstance;
  *
  * @package advancedworkflow
  */
-class GridFieldWorkflowRestrictedEditButton implements GridField_ColumnProvider
+class GridFieldWorkflowRestrictedEditButton extends AbstractGridFieldComponent implements GridField_ColumnProvider
 {
     /**
      * Add a column


### PR DESCRIPTION
This makes the `GridFieldExportAction` and `GridFieldWorkflowRestrictedEditButton` components `Injectable`, and allows any future enhancements in the new abstract class to automatically apply without requiring additional changes in this module.

The class is introduced in silverstripe/framework 4.11.0 (see silverstripe/silverstripe-framework#10204) so the dependency constraint needs to be updated.

Also use dependency injection instead of the `new` keyword when instantiating GridFields, their components, and configs.