### PR TITLE
MNT Fix yarn lint script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /node_modules/
+yarn-error.log

--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -1,10 +1,7 @@
 # sass-lint config to match the AirBNB style guide
 # See silverstripe-admin
 files:
-  include: '**/client/src/**/*.scss'
-  ignore:
-    - 'client/src/styles/legacy/*'
-    - 'src/**/*'
+  include: 'client/src/**/*.scss'
 options:
   formatter: stylish
   merge-default-rules: false

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "devDependencies": {
     "@silverstripe/webpack-config": "^0.5.1",
     "eslint": "^2.7.0",
-    "eslint-config-airbnb": "^6.2.0"
+    "eslint-config-airbnb": "^6.2.0",
+    "eslint-plugin-react": "^4.2.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1647,6 +1647,11 @@ eslint-config-airbnb@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/eslint-config-airbnb/-/eslint-config-airbnb-6.2.0.tgz#4a28196aa4617de01b8c914e992a82e5d0886a6e"
 
+eslint-plugin-react@^4.2.3:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-4.3.0.tgz#c79aac8069d62de27887c13b8298d592088de378"
+  integrity sha512-ajQ9S74FUln2GcwgpPUQqRLcT6UFDhvAMIiDX4F68tDnuihNXcAA7LI19MmRGGOuJnpMVDXugJg+wf9K+bf6kg==
+
 eslint@^2.7.0:
   version "2.13.1"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-2.13.1.tgz#e4cc8fa0f009fb829aaae23855a29360be1f6c11"


### PR DESCRIPTION
Follow-up from #462 

Fixes https://github.com/symbiote/silverstripe-advancedworkflow/runs/7402694217?check_suite_focus=true
> ESLint couldn't find the plugin "eslint-plugin-react"

and incorrectly linting the vendor dir.

## Parent issue
- https://github.com/silverstripe/gha-ci/issues/37