### PR TITLE
MNT Revert erroneous dependency changes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,10 +20,10 @@
     ],
     "require": {
         "php": "^7.4 || ^8.0",
-        "silverstripe/cms": "4.13.x-dev",
-        "silverstripe/framework": "4.13.x-dev",
-        "silverstripe/admin": "1.13.x-dev",
-        "silverstripe/versioned": "1.13.x-dev",
+        "silverstripe/cms": "^4",
+        "silverstripe/framework": "^4.11",
+        "silverstripe/admin": "^1",
+        "silverstripe/versioned": "^1",
         "symfony/yaml": "^3 || ^4"
     },
     "require-dev": {


### PR DESCRIPTION
Bad logic in cow resulted in many non-recipes having their constraints updated automatically when the beta was released.

## Issue
- https://github.com/silverstripe/.github/issues/33