### PR TITLE
FIX Argument order of insertBefore method

### DIFF
--- a/src/Extensions/WorkflowApplicable.php
+++ b/src/Extensions/WorkflowApplicable.php
@@ -265,7 +265,7 @@ class WorkflowApplicable extends DataExtension
                     }
                     // Only display menu if actions pushed to it
                     if ($tab->Fields()->exists()) {
-                        $menu->insertBefore($tab, 'MoreOptions');
+                        $menu->insertBefore('MoreOptions', $tab);
                     }
                 }
             }


### PR DESCRIPTION
<!--
  Thanks for contributing, you're awesome! ⭐

  Please read https://docs.silverstripe.org/en/contributing/code/ if you haven't contributed to this project recently.
-->
## Description
<!--
  Please describe expected and observed behaviour, and what you're fixing.
  For visual fixes, please include tested browsers and screenshots.
-->
When applying workflow to a page. There is an error related to an incorrect argument for insertBefore


```
[Emergency] Uncaught TypeError: SilverStripe\Forms\FieldList::insertBefore(): Argument #2 ($item) must be of type SilverStripe\Forms\FormField, string given, called in /Users/mo/Sites/cms/vendor/silverstripe/framework/src/Forms/CompositeField.php on line 349
```

## Manual testing steps
<!--
  Include any manual testing steps here which a reviewer can perform to validate your pull request works correctly.
  Note that this DOES NOT replace unit or end-to-end tests.
-->
- Create a new workflow and select a default template
- Fill in all required fields for workflow and save
- Create another workflow
- Go to Pages
- Edit a page
- Go to settings
- Select the workflow you have created in `Applied Workflow`
- Select the second workflow in `Additional Workflows`
- Save and go back to the Content tab
- There is an error about the incorrect argument


## Issues
<!--
  List all issues here that this pull request fixes/resolves.
  If there is no issue already, create a new one! You must link your pull request to at least one issue.
-->
- #514

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
