### PR TITLE
FIX Button layout that display icons

### DIFF
--- a/src/Extensions/WorkflowApplicable.php
+++ b/src/Extensions/WorkflowApplicable.php
@@ -256,7 +256,6 @@ class WorkflowApplicable extends DataExtension
                             // and will be displayed as a major action.
                             if (!$addedFirst) {
                                 $addedFirst = true;
-                                $action->setAttribute('data-icon', 'navigation');
                                 $majorActions = $actions->fieldByName('MajorActions');
                                 $majorActions ? $majorActions->push($action) : $actions->push($action);
                             } else {

--- a/templates/Symbiote/AdvancedWorkflow/FormFields/WorkflowField.ss
+++ b/templates/Symbiote/AdvancedWorkflow/FormFields/WorkflowField.ss
@@ -30,13 +30,13 @@
                     <h4>$Title</h4>
 
                     <div class="workflow-field-action-buttons btn-group">
-                        <a class="btn btn-outline-secondary workflow-field-open-dialog<% if $canEdit %><% else %> workflow-field-action-disabled<% end_if %>" href="$Top.ActionLink('item',$ID,'edit')" data-icon="pencil">
+                        <a class="btn btn-outline-secondary workflow-field-open-dialog<% if $canEdit %><% else %> workflow-field-action-disabled<% end_if %>" href="$Top.ActionLink('item',$ID,'edit')">
                             <%t WorkflowField.EditAction "Edit" %>
                         </a>
-                        <a class="btn btn-outline-secondary workflow-field-open-dialog <% if $canAddTransition %><% else %> workflow-field-action-disabled<% end_if %>" href="$Top.TransitionLink('new',$ID,'edit')" data-icon="chain--arrow">
+                        <a class="btn btn-outline-secondary workflow-field-open-dialog <% if $canAddTransition %><% else %> workflow-field-action-disabled<% end_if %>" href="$Top.TransitionLink('new',$ID,'edit')">
                             <%t WorkflowField.AddTransitionAction "Add Transition" %>
                         </a>
-                        <a href="$Top.ActionLink('item',$ID,'delete')" data-securityid="$SecurityID" class="btn btn-outline-secondary workflow-field-delete<% if $canDelete %><% else %> workflow-field-action-disabled<% end_if %>" data-icon="cross-circle">
+                        <a href="$Top.ActionLink('item',$ID,'delete')" data-securityid="$SecurityID" class="btn btn-outline-secondary workflow-field-delete<% if $canDelete %><% else %> workflow-field-action-disabled<% end_if %>">
                             <%t WorkflowField.DeleteAction "Delete" %>
                         </a>
                     </div>


### PR DESCRIPTION
<!--
  Thanks for contributing, you're awesome! ⭐

  Please read https://docs.silverstripe.org/en/contributing/code/ if you haven't contributed to this project recently.
-->
## Description
<!--
  Please describe expected and observed behaviour, and what you're fixing.
  For visual fixes, please include tested browsers and screenshots.
-->
The workflow interface looks like the following 
<img width="1057" alt="Screenshot 2024-01-25 at 12 13 13 PM" src="https://github.com/symbiote/silverstripe-advancedworkflow/assets/166450/75d55bca-4c03-4c68-861e-2c802b916057">

Similar issue in https://github.com/silverstripe/silverstripe-admin/pull/1581

## Manual testing steps
<!--
  Include any manual testing steps here which a reviewer can perform to validate your pull request works correctly.
  Note that this DOES NOT replace unit or end-to-end tests.
-->
- Install workflow
- Create a new one
- See the extra icons

## Issues
<!--
  List all issues here that this pull request fixes/resolves.
  If there is no issue already, create a new one! You must link your pull request to at least one issue.
-->
- #515

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
