### PR TITLE
DEP Bump minimum version of framework

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "silverstripe/cms": "^4",
-        "silverstripe/framework": "^4.11",
+        "silverstripe/framework": "^4.13",
         "silverstripe/admin": "^1",
         "silverstripe/versioned": "^1",
         "symfony/yaml": "^3 || ^4"


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/284

Failing on Deprecation::withNoReplacement() on --prefer-lowest build

https://github.com/symbiote/silverstripe-advancedworkflow/actions/runs/9851674315