### PR TITLE
FIX Update CMS fields now that they're being scaffolded

### DIFF
--- a/src/Extensions/WorkflowApplicable.php
+++ b/src/Extensions/WorkflowApplicable.php
@@ -53,6 +53,15 @@ class WorkflowApplicable extends DataExtension
         'AdditionalWorkflowDefinitions' => WorkflowDefinition::class
     ];
 
+    private static array $scaffold_cms_fields_settings = [
+        'ignoreFields' => [
+            'WorkflowDefinition',
+        ],
+        'ignoreRelations' => [
+            'AdditionalWorkflowDefinitions',
+        ],
+    ];
+
     private static $dependencies = [
         'workflowService' => '%$' . WorkflowService::class,
     ];


### PR DESCRIPTION
Relies on changes to `SiteTree` in https://github.com/silverstripe/silverstripe-cms/pull/2983


## Issue
- https://github.com/silverstripe/silverstripe-cms/issues/2767