### PR TITLE
FIX Update HTML markup for bootstrap 5

### DIFF
--- a/templates/Symbiote/AdvancedWorkflow/FormFields/WorkflowField.ss
+++ b/templates/Symbiote/AdvancedWorkflow/FormFields/WorkflowField.ss
@@ -57,10 +57,10 @@
                                 </span>
                                 <div class="btn-group workflow-transition-actions">
                                     <a href="$Top.TransitionLink('item', $ID, 'edit')" class="btn btn-secondary font-icon-edit workflow-field-open-dialog<% if $canEdit %><% else %> workflow-field-action-disabled<% end_if %>">
-                                        <span class="sr-only"><%t WorkflowField.EditAction "Edit" %></span>
+                                        <span class="visually-hidden"><%t WorkflowField.EditAction "Edit" %></span>
                                     </a>
                                     <a href="$Top.TransitionLink('item', $ID, 'delete')" data-securityid="$SecurityID" class="btn btn-secondary font-icon-trash workflow-field-delete<% if $canDelete %><% else %> workflow-field-action-disabled<% end_if %>">
-                                        <span class="sr-only"><%t WorkflowField.DeleteAction "Delete" %></span>
+                                        <span class="visually-hidden"><%t WorkflowField.DeleteAction "Delete" %></span>
                                     </a>
                                 </div>
                             </li>

--- a/templates/Symbiote/AdvancedWorkflow/Forms/GridField/GridFieldExportAction.ss
+++ b/templates/Symbiote/AdvancedWorkflow/Forms/GridField/GridFieldExportAction.ss
@@ -2,5 +2,5 @@
     class="grid-field__icon-action {$ExtraClass} no-ajax export-link"
     href="$Link" title="<%t Symbiote\\AdvancedWorkflow\\Forms\\GridField\\GridFieldExportAction.Export 'Export' %>"
 >
-    <span class="sr-only"><%t Symbiote\\AdvancedWorkflow\\Forms\\GridField\\GridFieldExportAction.Export 'Export' %></span>
+    <span class="visually-hidden"><%t Symbiote\\AdvancedWorkflow\\Forms\\GridField\\GridFieldExportAction.Export 'Export' %></span>
 </a>


### PR DESCRIPTION
See https://github.com/silverstripe/silverstripe-admin/pull/1889 which links to the specific upgrade guide entries for most changes made.

## Upgrade docs

- [boostrap](https://getbootstrap.com/docs/5.0/migration/)
- [reactstrap](https://reactstrap.github.io/?path=/story/home-upgrading--page)

## Issue
- https://github.com/silverstripe/.github/issues/332