### PR TITLE
FIX Log warnings instead of hard errors when notification fails.

### DIFF
--- a/src/Actions/NotifyUsersWorkflowAction.php
+++ b/src/Actions/NotifyUsersWorkflowAction.php
@@ -2,6 +2,7 @@
 
 namespace Symbiote\AdvancedWorkflow\Actions;
 
+use Psr\Log\LoggerInterface;
 use SilverStripe\Control\Email\Email;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Forms\HeaderField;
@@ -17,9 +18,9 @@ use SilverStripe\Security\Security;
 use SilverStripe\Model\ArrayData;
 use SilverStripe\View\TemplateEngine;
 use SilverStripe\View\ViewLayerData;
-use Swift_RfcComplianceException;
 use Symbiote\AdvancedWorkflow\DataObjects\WorkflowAction;
 use Symbiote\AdvancedWorkflow\DataObjects\WorkflowInstance;
+use Symfony\Component\Mime\Exception\RfcComplianceException;
 
 /**
  * A workflow action that notifies users attached to the workflow path that they have a task awaiting them.
@@ -86,9 +87,21 @@ class NotifyUsersWorkflowAction extends WorkflowAction
 
     public function execute(WorkflowInstance $workflow)
     {
+        if (!$this->EmailTemplate) {
+            Injector::inst()->get(LoggerInterface::class)->warning(
+                'No email template available for notify users workflow action '
+                . "'{$this->Title}' in workflow '{$this->WorkflowDef()?->Title}'."
+            );
+            return true;
+        }
+
         $members = $workflow->getAssignedMembers();
 
         if (!$members || !count($members ?? [])) {
+            Injector::inst()->get(LoggerInterface::class)->warning(
+                'No members to send emails to for notify users workflow action '
+                . "'{$this->Title}' in workflow '{$this->WorkflowDef()?->Title}'."
+            );
             return true;
         }
 
@@ -137,6 +150,7 @@ class NotifyUsersWorkflowAction extends WorkflowAction
         }
 
         $engine = Injector::inst()->create(TemplateEngine::class);
+        $emailSent = false;
         foreach ($members as $member) {
             if ($member->Email) {
                 // We bind in the assignee at this point, as it changes each loop iteration
@@ -150,16 +164,26 @@ class NotifyUsersWorkflowAction extends WorkflowAction
                 $email = Email::create();
                 try {
                     $email->setTo($member->Email);
-                } catch (Swift_RfcComplianceException $exception) {
+                } catch (RfcComplianceException) {
                     // If the email address isn't valid we should skip it rather than break
                     // the rest of the processing
                     continue;
                 }
                 $email->setSubject($subject);
-                $email->setFrom($from);
+                if ($from) {
+                    $email->setFrom($from);
+                }
                 $email->setBody($body);
                 $email->send();
+                $emailSent = true;
             }
+        }
+
+        if (!$emailSent) {
+            Injector::inst()->get(LoggerInterface::class)->warning(
+                'No email was sent for notify users workflow action '
+                . "'{$this->Title}' in workflow '{$this->WorkflowDef()?->Title}'."
+            );
         }
 
         return true;


### PR DESCRIPTION
Adds some additional logging for when no email is sent for various reasons. This should either prompt removal of the notify action (if no notification is necessary) or update it (if it is necessary) without throwing obscure errors in content authors' faces.

## Issues
- https://github.com/symbiote/silverstripe-advancedworkflow/issues/574
- https://github.com/symbiote/silverstripe-advancedworkflow/issues/575
- https://github.com/symbiote/silverstripe-advancedworkflow/issues/576