### PR TITLE
ENH Use new DataList caching

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "require": {
         "php": "^8.3",
         "silverstripe/cms": "^6",
-        "silverstripe/framework": "^6",
+        "silverstripe/framework": "^6.1",
         "silverstripe/admin": "^3",
         "silverstripe/versioned": "^3",
         "symfony/yaml": "^7.0"

--- a/src/Admin/AdvancedWorkflowAdmin.php
+++ b/src/Admin/AdvancedWorkflowAdmin.php
@@ -275,7 +275,7 @@ class AdvancedWorkflowAdmin extends ModelAdmin
             }
             // @todo can we use $this->getDefinitionFor() to fetch the "Parent" definition of $instance? Maybe
             // define $this->workflowParent()
-            $effectiveWorkflow = DataObject::get_by_id(WorkflowDefinition::class, $instance->DefinitionID);
+            $effectiveWorkflow = WorkflowDefinition::get()->setUseCache(true)->byID($instance->DefinitionID);
             $target = $instance->getTarget();
             if (!is_object($effectiveWorkflow) || !$target) {
                 continue;

--- a/src/Admin/WorkflowDefinitionExporter.php
+++ b/src/Admin/WorkflowDefinitionExporter.php
@@ -58,7 +58,7 @@ class WorkflowDefinitionExporter
     public function __construct($definitionID)
     {
         $this->setMember(Security::getCurrentUser());
-        $this->workflowDefinition = DataObject::get_by_id(WorkflowDefinition::class, $definitionID);
+        $this->workflowDefinition = WorkflowDefinition::get()->setUseCache(true)->byID($definitionID);
     }
 
     /**

--- a/src/Controllers/AdvancedWorkflowActionController.php
+++ b/src/Controllers/AdvancedWorkflowActionController.php
@@ -34,9 +34,9 @@ class AdvancedWorkflowActionController extends Controller
         $id = $this->request->requestVar('id');
         $transition = $this->request->requestVar('transition');
 
-        $instance = DataObject::get_by_id(WorkflowInstance::class, (int) $id);
+        $instance = WorkflowInstance::get()->setUseCache(true)->byID((int) $id);
         if ($instance && $instance->canEdit()) {
-            $transition = DataObject::get_by_id(WorkflowTransition::class, (int) $transition);
+            $transition = WorkflowTransition::get()->setUseCache(true)->byID((int) $transition);
             if ($transition) {
                 if ($this->request->requestVar('comments')) {
                     $action = $instance->CurrentAction();

--- a/src/Controllers/FrontEndWorkflowController.php
+++ b/src/Controllers/FrontEndWorkflowController.php
@@ -43,7 +43,7 @@ abstract class FrontEndWorkflowController extends Controller
         if (!$this->contextObj) {
             if ($id = $this->getContextID()) {
                 $cType = $this->getContextType();
-                $cObj = DataObject::get_by_id($cType, $id);
+                $cObj = DataObject::get($cType)->setUseCache(true)->byID($id);
                 if ($cObj) {
                     $this->contextObj = $cObj->canView() ? $cObj : null;
                 }
@@ -140,7 +140,7 @@ abstract class FrontEndWorkflowController extends Controller
     {
         $trans = null;
         if ($this->transitionID) {
-            $trans = DataObject::get_by_id(WorkflowTransition::class, $this->transitionID);
+            $trans = WorkflowTransition::get()->setUseCache(true)->byID($this->transitionID);
         }
         return $trans;
     }

--- a/src/DataObjects/WorkflowDefinition.php
+++ b/src/DataObjects/WorkflowDefinition.php
@@ -183,7 +183,7 @@ class WorkflowDefinition extends DataObject
         $this->Users()->removeAll();
         $this->Groups()->removeAll();
         $this->Actions()->each(function ($action) {
-            if ($orphan = DataObject::get_by_id(WorkflowAction::class, $action->ID)) {
+            if ($orphan = WorkflowAction::get()->setUseCache(true)->byID($action->ID)) {
                 $orphan->delete();
             }
         });

--- a/src/DataObjects/WorkflowInstance.php
+++ b/src/DataObjects/WorkflowInstance.php
@@ -271,7 +271,7 @@ class WorkflowInstance extends DataObject
                 )->byID($this->TargetID);
             }
             if (!$targetObject) {
-                $targetObject = DataObject::get_by_id($this->TargetClass, $this->TargetID);
+                $targetObject = DataObject::get($this->TargetClass)->setUseCache(true)->byID($this->TargetID);
             }
 
             return $targetObject;
@@ -467,7 +467,7 @@ class WorkflowInstance extends DataObject
 
         $action->actionComplete($transition);
 
-        $definition = DataObject::get_by_id(WorkflowAction::class, $transition->NextActionID);
+        $definition = WorkflowAction::get()->setUseCache(true)->byID($transition->NextActionID);
         $action = $definition->getInstanceForWorkflow();
         $action->WorkflowID   = $this->ID;
         $action->write();

--- a/src/DataObjects/WorkflowTransition.php
+++ b/src/DataObjects/WorkflowTransition.php
@@ -109,7 +109,7 @@ class WorkflowTransition extends DataObject
         $attachTo = $this->ActionID ? $this->ActionID : $reqParent;
 
         if ($attachTo) {
-            $action = DataObject::get_by_id(WorkflowAction::class, $attachTo);
+            $action = WorkflowAction::get()->setUseCache(true)->byID($attachTo);
             if ($action && $action->ID) {
                 $filter = '"WorkflowDefID" = '.((int) $action->WorkflowDefID);
             }

--- a/src/Services/WorkflowService.php
+++ b/src/Services/WorkflowService.php
@@ -91,7 +91,7 @@ class WorkflowService implements PermissionProvider
             || $dataObject->hasExtension(FileWorkflowApplicable::class)
         ) {
             if ($dataObject->WorkflowDefinitionID) {
-                return DataObject::get_by_id(WorkflowDefinition::class, $dataObject->WorkflowDefinitionID);
+                return WorkflowDefinition::get()->setUseCache(true)->byID($dataObject->WorkflowDefinitionID);
             }
             if ($dataObject->hasMethod('useInheritedWorkflow') && !$dataObject->useInheritedWorkflow()) {
                 return null;
@@ -130,7 +130,7 @@ class WorkflowService implements PermissionProvider
                 || ($workflow = $object->AdditionalWorkflowDefinitions()->byID($workflowID))
             ) {
                 if (is_null($workflow)) {
-                    $workflow = DataObject::get_by_id(WorkflowDefinition::class, $workflowID);
+                    $workflow = WorkflowDefinition::get()->setUseCache(true)->byID($workflowID);
                 }
             }
         }
@@ -180,20 +180,19 @@ class WorkflowService implements PermissionProvider
 
         if ($item instanceof WorkflowAction) {
             $id = $item->WorkflowID;
-            return DataObject::get_by_id(WorkflowInstance::class, $id);
+            return WorkflowInstance::get()->setUseCache(true)->byID($id);
         } elseif (is_object($item) && ($item->hasExtension(WorkflowApplicable::class)
                 || $item->hasExtension(FileWorkflowApplicable::class))
         ) {
-            $filter = sprintf(
-                '"TargetClass" = \'%s\' AND "TargetID" = %d',
-                Convert::raw2sql(DataObject::getSchema()->baseDataClass($item)),
-                $item->ID
-            );
-            $complete = $includeComplete ? 'OR "WorkflowStatus" = \'Complete\' ' : '';
-            return DataObject::get_one(
-                WorkflowInstance::class,
-                $filter . ' AND ("WorkflowStatus" = \'Active\' OR "WorkflowStatus"=\'Paused\' ' . $complete . ')'
-            );
+            $statuses = ['Active', 'Paused'];
+            if ($includeComplete) {
+                $statuses[] = 'Complete';
+            }
+            return WorkflowInstance::get()->setUseCache(true)->filter([
+                'TargetClass' => DataObject::getSchema()->baseDataClass($item),
+                'TargetID' => $item->ID,
+                'WorkflowStatus' => $statuses,
+            ])->first();
         }
     }
 
@@ -235,7 +234,7 @@ class WorkflowService implements PermissionProvider
     public function executeTransition(DataObject $target, $transitionId)
     {
         $workflow   = $this->getWorkflowFor($target);
-        $transition = DataObject::get_by_id(WorkflowTransition::class, $transitionId);
+        $transition = WorkflowTransition::get()->setUseCache(true)->byID($transitionId);
 
         if (!$transition) {
             throw new Exception(_t('WorkflowService.INVALID_TRANSITION_ID', "Invalid transition ID $transitionId"));

--- a/src/Templates/WorkflowTemplate.php
+++ b/src/Templates/WorkflowTemplate.php
@@ -420,7 +420,7 @@ class WorkflowTemplate
             if (isset($source['users']) && is_array($source['users'])) {
                 foreach ($source['users'] as $user) {
                     $email = Convert::raw2sql($user['email']);
-                    if ($_user = DataObject::get_one(Member::class, "Email = '".$email."'")) {
+                    if ($_user = Member::get()->setUseCache(true)->find('Email', $email)) {
                         $object->Users()->add($_user);
                     }
                 }
@@ -436,7 +436,7 @@ class WorkflowTemplate
             if (isset($source['groups']) && is_array($source['groups'])) {
                 foreach ($source['groups'] as $group) {
                     $title = Convert::raw2sql($group['title']);
-                    if ($_group = DataObject::get_one(Group::class, "Title = '".$title."'")) {
+                    if ($_group = Group::get()->setUseCache(true)->find('Title', $title)) {
                         $object->Groups()->add($_group);
                     }
                 }

--- a/tests/php/WorkflowEngineTest.php
+++ b/tests/php/WorkflowEngineTest.php
@@ -5,6 +5,7 @@ namespace Symbiote\AdvancedWorkflow\Tests;
 use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\ORM\DataObject;
+use SilverStripe\Security\Member;
 use SilverStripe\Versioned\Versioned;
 use Symbiote\AdvancedWorkflow\Actions\AssignUsersToWorkflowAction;
 use Symbiote\AdvancedWorkflow\Actions\NotifyUsersWorkflowAction;
@@ -138,7 +139,7 @@ class WorkflowEngineTest extends SapphireTest
 
         $action->execute($instance);
 
-        $page = DataObject::get_by_id(SiteTree::class, $page->ID);
+        $page = SiteTree::get()->byID($page->ID);
         $this->assertTrue($page->isPublished());
     }
 
@@ -223,12 +224,12 @@ class WorkflowEngineTest extends SapphireTest
 
         // Test a user with lame permissions
         $memberID = $this->logInWithPermission('SITETREE_VIEW_ALL');
-        $member = DataObject::get_by_id('SilverStripe\\Security\\Member', $memberID);
+        $member = Member::get()->byID($memberID);
         $this->assertFalse($def->canCreate($member));
 
         // Test a user with good permissions
         $memberID = $this->logInWithPermission('CREATE_WORKFLOW');
-        $member = DataObject::get_by_id('SilverStripe\\Security\\Member', $memberID);
+        $member = Member::get()->byID($memberID);
         $this->assertTrue($def->canCreate($member));
     }
 
@@ -263,7 +264,7 @@ class WorkflowEngineTest extends SapphireTest
         $instance->execute();
 
         // Check the content is assigned
-        $testPage = DataObject::get_by_id(SiteTree::class, $page->ID);
+        $testPage = SiteTree::get()->byID($page->ID);
         $this->assertEquals($instance->TargetID, $testPage->ID);
 
         // 3). Delete the workflow


### PR DESCRIPTION
Replaces deprecated `DataObject::get_one()` and `DataObject::get_by_id()` in favour of the new DataList query caching.

Tests have been updated to remove caching where it's not relevant to the test.

> [!IMPORTANT]
> Relies on https://github.com/silverstripe/silverstripe-framework/pull/11768
> DO NOT MERGE until that PR has been merged in

## Issue

- https://github.com/silverstripe/silverstripe-framework/issues/11767
