### PR TITLE
ENH Optimise SQL queries to improve performance

### DIFF
--- a/src/Controllers/AdvancedWorkflowActionController.php
+++ b/src/Controllers/AdvancedWorkflowActionController.php
@@ -32,19 +32,19 @@ class AdvancedWorkflowActionController extends Controller
         }
 
         $id = $this->request->requestVar('id');
-        $transition = $this->request->requestVar('transition');
+        $transitionID = (int) $this->request->requestVar('transition');
 
         $instance = WorkflowInstance::get()->setUseCache(true)->byID((int) $id);
         if ($instance && $instance->canEdit()) {
-            $transition = WorkflowTransition::get()->setUseCache(true)->byID((int) $transition);
-            if ($transition) {
+            $transitionExists = WorkflowTransition::get()->setUseCache(true)->filter('ID', $transitionID)->exists();
+            if ($transitionExists) {
                 if ($this->request->requestVar('comments')) {
                     $action = $instance->CurrentAction();
                     $action->Comment = $this->request->requestVar('comments');
                     $action->write();
                 }
 
-                singleton(WorkflowService::class)->executeTransition($instance->getTarget(), $transition->ID);
+                singleton(WorkflowService::class)->executeTransition($instance->getTarget(), $transitionID);
                 $result = array(
                     'success' => true,
                     'link'    => $instance->getTarget()->AbsoluteLink()

--- a/src/Controllers/FrontEndWorkflowController.php
+++ b/src/Controllers/FrontEndWorkflowController.php
@@ -6,6 +6,7 @@ use Exception;
 use SilverStripe\Control\Controller;
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Forms\Form;
+use SilverStripe\Model\List\SS_List;
 use SilverStripe\ORM\DataObject;
 use Symbiote\AdvancedWorkflow\DataObjects\WorkflowTransition;
 use Symbiote\AdvancedWorkflow\Forms\FrontendWorkflowForm;
@@ -187,10 +188,11 @@ abstract class FrontEndWorkflowController extends Controller
         $action->BaseAction()->execute($this->contextObj->getWorkflowInstance());
 
         //get valid transitions
+        /** @var SS_List $transitions */
         $transitions = $action->getValidTransitions();
 
         //tell instance to execute transition if it's in the permitted list
-        if ($transitions->find('ID', $this->transitionID)) {
+        if ($transitions->filter('ID', $this->transitionID)->exists()) {
             $this->contextObj->getWorkflowInstance()->performTransition($this->getCurrentTransition());
         }
     }

--- a/src/DataObjects/WorkflowInstance.php
+++ b/src/DataObjects/WorkflowInstance.php
@@ -455,7 +455,7 @@ class WorkflowInstance extends DataObject
         $action          = $this->CurrentAction();
         $allTransitions  = $action->BaseAction()->Transitions();
 
-        $valid = $allTransitions->find('ID', $transition->ID);
+        $valid = $allTransitions->filter('ID', $transition->ID)->exists();
         if (!$valid) {
             throw new Exception(
                 sprintf(_t(
@@ -585,7 +585,8 @@ class WorkflowInstance extends DataObject
         // This method primarily "protects" access to a WorkflowInstance, but assumes access only to be granted to
         // users assigned-to that WorkflowInstance. However; lowly authors (users entering items into a workflow) are
         // not assigned - but we still wish them to see their submitted content.
-        $inWorkflowGroupOrUserTables = ($member->inGroups($this->Groups()) || $this->Users()->find('ID', $member->ID));
+        $inWorkflowGroupOrUserTables = $this->Users()->filter('ID', $member->ID)->exists()
+            || $member->inGroups($this->Groups());
         // This method is used in more than just the ModelAdmin. Check for the current controller to determine where
         // canView() expectations differ
         if ($this->getTarget() && Controller::curr()->getAction() == 'index' && !$inWorkflowGroupOrUserTables) {

--- a/src/DataObjects/WorkflowTransition.php
+++ b/src/DataObjects/WorkflowTransition.php
@@ -207,7 +207,7 @@ class WorkflowTransition extends DataObject
 
         // If not admin, check if the member is in the list of assigned members
         if (!Permission::check('ADMIN') && $members->exists()) {
-            if (!$members->find('ID', Security::getCurrentUser()->ID)) {
+            if (!$members->filter('ID', Security::getCurrentUser()->ID)->exists()) {
                 $return = false;
             }
         }


### PR DESCRIPTION
While not reducing the _number_ of queries, I've updated a bunch of calls to `find()` and `byID()` (which were only being used to check if a record exists) to instead use `filter()->exists()` which is more efficient.

## Issue

- https://github.com/silverstripe/.github/issues/416